### PR TITLE
Add `llt` quasiquoter for Terminator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ cabal.sandbox.config
 *~
 *#*#
 .stack-work
+
+# For IntelliJ IDEA
+/.idea

--- a/src/LLVM/Quote/Base.hs
+++ b/src/LLVM/Quote/Base.hs
@@ -242,6 +242,11 @@ instance QQExp A.Instruction L.Instruction where
                     case x1' :: Either L.Instruction L.Terminator of
                       Left  x1'' -> return x1''
                       Right x1'' -> fail $ show x1'' ++ " is no Instruction"||]
+instance QQExp A.Instruction L.Terminator where
+  qqExpM x1 = [||do x1' <- $$(qqExpM x1)
+                    case x1' :: Either L.Instruction L.Terminator of
+                      Left  x1'' -> fail $ show x1'' ++ " is no Terminator"
+                      Right x1'' -> return x1''||]
 instance QQExp [A.LabeledInstruction] [L.BasicBlock] where
   qqExpM = qqLabeledInstructionListE
 instance QQExp A.NamedInstruction [L.BasicBlock] where

--- a/src/LLVM/Quote/LLVM.hs
+++ b/src/LLVM/Quote/LLVM.hs
@@ -5,6 +5,7 @@ module LLVM.Quote.LLVM (
     -- llbb,
     -- llbbs,
     lli,
+    llt,
     llmodM,
     lldefM,
     llgM,
@@ -42,6 +43,10 @@ lli :: QuasiQuoter
 lli = unTQuasiQuoter
         (quasiquote exts P.parseInstruction :: TQuasiQuoter L.Instruction)
 
+-- | Quasiquoter for 'LLVM.AST.Instruction.Terminator
+llt :: QuasiQuoter
+llt = unTQuasiQuoter
+        (quasiquote exts P.parseTerminator :: TQuasiQuoter L.Terminator)
 
 -- | Quasiquoter for 'LLVM.AST.Module'
 llmodM :: QuasiQuoter

--- a/src/LLVM/Quote/Parser/Parser.y
+++ b/src/LLVM/Quote/Parser/Parser.y
@@ -279,6 +279,7 @@ import qualified LLVM.DataLayout as A
 %name parseDefinition   definition
 %name parseGlobal       global
 %name parseInstruction  instruction
+%name parseTerminator   instruction
 
 %%
 

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -20,6 +20,9 @@ import qualified LLVM.AST.RMWOperation as RMWOp
 instruction :: Type -> Operand -> Instruction
 instruction ty op = [lli| call void @dummy_fuc($type:ty $opr:op) |]
 
+terminator :: Terminator
+terminator = [llt| ret i32 0 |]
+
 tests :: TestTree
 tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
   testGroup "regular" [


### PR DESCRIPTION
I added `llt` quasiquoter for creating Terminator. I'd like to create `Terminator` not only`Instruction`.

## Usage

```hs
terminator :: Terminator
terminator = [llt| ret i32 0 |]
```

## Underlying problems

The following code is valid in compile time. However, if you use `myinstruction` or `myterminator`, runtime error happens.

```hs
-- (Compile pass, but if you use this, runtime error happens)
myinstruction ::  Instruction
myinstruction = [lli| ret i32 0 |]
```

```hs
-- (Compile pass, but if you use this, runtime error happens)
myterminator :: Terminator
myterminator = [llt| add i32 1, 2 |]
```

There have been these problems. llvm-hs-quote makes us write safe code. So in the future, I hope it will be safer.