### PR TITLE
Allow LLVM.AST.Name.Name as label by using `$id`.

### DIFF
--- a/src/LLVM/Quote/Parser/Parser.y
+++ b/src/LLVM/Quote/Parser/Parser.y
@@ -764,6 +764,7 @@ instructions :
 jumpLabel :: { A.Name }
 jumpLabel :
     JUMPLABEL           { A.Name (fromString $1) }
+  | ANTI_ID             { A.AntiName (fromString $1) }
   | {- empty -}         { A.NeedsName }
 
 {------------------------------------------------------------------------------

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -23,6 +23,15 @@ instruction ty op = [lli| call void @dummy_fuc($type:ty $opr:op) |]
 terminator :: Terminator
 terminator = [llt| ret i32 0 |]
 
+moduleWithLabel :: Name -> Module
+moduleWithLabel lab = [llmod|
+  ; ModuleID = 'simple module'
+  define i32 @myfunc(){
+  $id:lab
+    ret i32 0
+  }
+|]
+
 tests :: TestTree
 tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
   testGroup "regular" [


### PR DESCRIPTION
I allowed library users to use `LLVM.AST.Name.Name` as jump label by using `$id`.
This feature was proposed in #13.

## Usage

```hs
-- practice of $id for label
module9 :: AST.Name -> AST.Module
module9 lab = [Quote.LLVM.llmod|
  ; ModuleID = 'simple module'
  define i32 @myfunc(){
  $id:lab
    ret i32 0
  }
|]

main = toLLVM (module9 (AST.Name "mylabel"))
```

## output

```txt
; ModuleID = '<string>'
source_filename = "<string>"

define i32 @myfunc() {
mylabel:
  ret i32 0
}
```