### PR TITLE
Fix `phi` and `ret` instructions

### DIFF
--- a/src/LLVM/Quote/Parser/Parser.y
+++ b/src/LLVM/Quote/Parser/Parser.y
@@ -514,7 +514,7 @@ clauses :
 
 phiItem :: { A.Type -> (A.Operand, A.Name) }
 phiItem :
-    '[' operand ',' name ']'     { \t -> ($2 t, $4) }
+    '[' coperand ',' name ']'    { \t -> ($2 t, $4) }
 
 phiList :: { A.Type -> RevList (A.Operand, A.Name) }
 phiList :

--- a/src/LLVM/Quote/Parser/Parser.y
+++ b/src/LLVM/Quote/Parser/Parser.y
@@ -711,7 +711,7 @@ instruction_ :
   | 'landingpad' type cleanup clauses
                                             { A.LandingPad $2 $3 (rev $4) }
   | 'ret' 'void'                            { A.Ret Nothing }
-  | 'ret' typeNoVoid operand                { A.Ret (Just ($3 $2)) }
+  | 'ret' typeNoVoid coperand               { A.Ret (Just ($3 $2)) }
   | 'br' 'label' name                       { A.Br $3 }
   | 'br' tOperand ',' 'label' name ',' 'label' name
 					    { A.CondBr ($2) $5 $8 }

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -36,6 +36,13 @@ phi2 :: Type -> Operand -> Operand -> Name -> Name -> Instruction
 phi2 ty op1 op2 label1 label2 = [lli|phi $type:ty [$opr:op1, $id:label1], [$opr:op2, $id:label2]|]
 
 
+retWithName :: Type -> Name -> Terminator
+retWithName ty name = [llt|ret $type:ty $id:name|]
+
+retWithOp :: Type -> Operand -> Terminator
+retWithOp ty op = [llt|ret $type:ty $opr:op|]
+
+
 tests :: TestTree
 tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
   testGroup "regular" [

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -29,6 +29,13 @@ brWithName condName n1 n2 = [lli|br i1 $id:condName, label $id:n1, label $id:n2|
 brWithOp :: Operand -> Name -> Name -> Instruction
 brWithOp cond n1 n2 = [lli|br $opr:cond, label $id:n1, label $id:n2|]
 
+phi1 :: Type -> Name -> Name -> Name -> Name -> Instruction
+phi1 ty vName1 vName2 label1 label2 = [lli|phi $type:ty [$id:vName1, $id:label1], [$id:vName2, $id:label2]|]
+
+phi2 :: Type -> Operand -> Operand -> Name -> Name -> Instruction
+phi2 ty op1 op2 label1 label2 = [lli|phi $type:ty [$opr:op1, $id:label1], [$opr:op2, $id:label2]|]
+
+
 tests :: TestTree
 tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
   testGroup "regular" [


### PR DESCRIPTION
Hi, developers

This pull request is a solution for a problem bellow.

`phi1` bellow is already OK.

```hs
phi1 :: Type -> Name -> Name -> Name -> Name -> Instruction
phi1 ty vName1 vName2 label1 label2 = [lli|phi $type:ty [$id:vName1, $id:label1], [$id:vName2, $id:label2]|]
```

But, `phi2` bellow had had a compile error.

```hs
phi2 :: Type -> Operand -> Operand -> Name -> Name -> Instruction
phi2 ty op1 op2 label1 label2 = [lli|phi $type:ty [$opr:op1, $id:label1], [$opr:op2, $id:label2]|]
````


Compile error:
```
      Code: template-haskell-2.12.0.0:Language.Haskell.TH.Quote.quoteExp
              lli "phi $type:ty [$opr:op1, $id:label1], [$opr:op2, $id:label2]"
    • In the quasi-quotation:
        [lli|phi $type:ty [$opr:op1, $id:label1], [$opr:op2, $id:label2]|]
   |         
36 | phi2 ty op1 op2 label1 label2 = [lli|phi $type:ty [$opr:op1, $id:label1], [$opr:op2, $id:label2]|]
   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^          
```

This pull request is a solution for the problem.