### PR TITLE
Support of Constant Expressions

### DIFF
--- a/src/LLVM/Quote/AST.hs
+++ b/src/LLVM/Quote/AST.hs
@@ -581,6 +581,21 @@ data Constant
     | BlockAddress { blockAddressFunction :: Name, blockAddressBlock :: Name }
     | GlobalReference Type Name
     | AntiConstant ShortByteString
+    {- TODO: Implement other constant expressions -}
+    | Add' {
+        nsw' :: Bool,
+        nuw' :: Bool,
+        operand0'' :: Constant,
+        operand1'' :: Constant
+      }
+    | FAdd' {
+        operand0'' :: Constant,
+        operand1'' :: Constant
+      }
+    | BitCast' {
+        operand0'' :: Constant,
+        type'' :: Type
+      }
     deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 {- |

--- a/src/LLVM/Quote/AST.hs
+++ b/src/LLVM/Quote/AST.hs
@@ -581,7 +581,6 @@ data Constant
     | BlockAddress { blockAddressFunction :: Name, blockAddressBlock :: Name }
     | GlobalReference Type Name
     | AntiConstant ShortByteString
-    {- TODO: Implement other constant expressions -}
     | Add' {
         nsw' :: Bool,
         nuw' :: Bool,
@@ -592,18 +591,174 @@ data Constant
         operand0'' :: Constant,
         operand1'' :: Constant
       }
+    | Sub' {
+        nsw' :: Bool,
+        nuw' :: Bool,
+        operand0'' :: Constant,
+        operand1'' :: Constant
+      }
+    | FSub' {
+        operand0'' :: Constant,
+        operand1'' :: Constant
+      }
+    | Mul' {
+        nsw' :: Bool,
+        nuw' :: Bool,
+        operand0'' :: Constant,
+        operand1'' :: Constant
+      }
+    | FMul' {
+        operand0'' :: Constant,
+        operand1'' :: Constant
+      }
+    | UDiv' {
+        exact' :: Bool,
+        operand0'' :: Constant,
+        operand1'' :: Constant
+      }
+    | SDiv' {
+        exact' :: Bool,
+        operand0'' :: Constant,
+        operand1'' :: Constant
+      }
+    | FDiv' {
+        operand0'' :: Constant,
+        operand1'' :: Constant
+      }
+    | URem' {
+        operand0'' :: Constant,
+        operand1'' :: Constant
+      }
+    | SRem' {
+        operand0'' :: Constant,
+        operand1'' :: Constant
+      }
+    | FRem' {
+        operand0'' :: Constant,
+        operand1'' :: Constant
+      }
+    | Shl' {
+        nsw' :: Bool,
+        nuw' :: Bool,
+        operand0'' :: Constant,
+        operand1'' :: Constant
+      }
+    | LShr' {
+        exact' :: Bool,
+        operand0'' :: Constant,
+        operand1'' :: Constant
+      }
+    | AShr' {
+        exact' :: Bool,
+        operand0'' :: Constant,
+        operand1'' :: Constant
+      }
+    | And' {
+        operand0'' :: Constant,
+        operand1'' :: Constant
+      }
+    | Or' {
+        operand0'' :: Constant,
+        operand1'' :: Constant
+      }
+    | Xor' {
+        operand0'' :: Constant,
+        operand1'' :: Constant
+      }
     | GetElementPtr' {
         inBounds' :: Bool,
-        address'  :: Constant,
+        address' :: Constant,
         indices'' :: [Constant]
+      }
+    | Trunc' {
+        operand0'' :: Constant,
+        type'' :: Type
+      }
+    | ZExt' {
+        operand0'' :: Constant,
+        type'' :: Type
+      }
+    | SExt' {
+        operand0'' :: Constant,
+        type'' :: Type
+      }
+    | FPToUI' {
+        operand0'' :: Constant,
+        type'' :: Type
+      }
+    | FPToSI' {
+        operand0'' :: Constant,
+        type'' :: Type
+      }
+    | UIToFP' {
+        operand0'' :: Constant,
+        type'' :: Type
+      }
+    | SIToFP' {
+        operand0'' :: Constant,
+        type'' :: Type
+      }
+    | FPTrunc' {
+        operand0'' :: Constant,
+        type'' :: Type
+      }
+    | FPExt' {
+        operand0'' :: Constant,
+        type'' :: Type
       }
     | PtrToInt' {
         operand0'' :: Constant,
-        type''     :: Type
+        type'' :: Type
+      }
+    | IntToPtr' {
+        operand0'' :: Constant,
+        type'' :: Type
       }
     | BitCast' {
         operand0'' :: Constant,
         type'' :: Type
+      }
+    | AddrSpaceCast' {
+        operand0'' :: Constant,
+        type'' :: Type
+      }
+    | ICmp' {
+        iPredicate' :: AI.IntegerPredicate,
+        operand0'' :: Constant,
+        operand1'' :: Constant
+      }
+    | FCmp' {
+        fpPredicate' :: AF.FloatingPointPredicate,
+        operand0'' :: Constant,
+        operand1'' :: Constant
+      }
+    | Select' {
+        condition'' :: Constant,
+        trueValue' :: Constant,
+        falseValue' :: Constant
+      }
+    | ExtractElement' {
+        vector' :: Constant,
+        index' :: Constant
+      }
+    | InsertElement' {
+        vector' :: Constant,
+        element' :: Constant,
+        index' :: Constant
+      }
+    | ShuffleVector' {
+        operand0'' :: Constant,
+        operand1'' :: Constant,
+        mask' :: Constant
+      }
+    | ExtractValue' {
+        aggregate' :: Constant,
+        indices''' :: [Word32]
+      }
+    | InsertValue' {
+        aggregate' :: Constant,
+        element' :: Constant,
+        indices''' :: [Word32]
       }
     deriving (Eq, Ord, Read, Show, Typeable, Data)
 

--- a/src/LLVM/Quote/AST.hs
+++ b/src/LLVM/Quote/AST.hs
@@ -592,6 +592,11 @@ data Constant
         operand0'' :: Constant,
         operand1'' :: Constant
       }
+    | GetElementPtr' {
+        inBounds' :: Bool,
+        address'  :: Constant,
+        indices'' :: [Constant]
+      }
     | BitCast' {
         operand0'' :: Constant,
         type'' :: Type

--- a/src/LLVM/Quote/AST.hs
+++ b/src/LLVM/Quote/AST.hs
@@ -597,6 +597,10 @@ data Constant
         address'  :: Constant,
         indices'' :: [Constant]
       }
+    | PtrToInt' {
+        operand0'' :: Constant,
+        type''     :: Type
+      }
     | BitCast' {
         operand0'' :: Constant,
         type'' :: Type

--- a/src/LLVM/Quote/Base.hs
+++ b/src/LLVM/Quote/Base.hs
@@ -620,12 +620,82 @@ qqConstantE (A.Add' x1 x2 x3 x4) =
   [||LConstant.Add <$> $$(qqExpM x1) <*> $$(qqExpM x2) <*> $$(qqExpM x3) <*> $$(qqExpM x4)||]
 qqConstantE (A.FAdd' x1 x2) =
   [||LConstant.FAdd <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
-qqConstantE (A.BitCast' x1 x2) =
-  [||LConstant.BitCast <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.Sub' x1 x2 x3 x4) =
+  [||LConstant.Sub <$> $$(qqExpM x1) <*> $$(qqExpM x2) <*> $$(qqExpM x3) <*> $$(qqExpM x4)||]
+qqConstantE (A.FSub' x1 x2) =
+ [||LConstant.FSub <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.Mul' x1 x2 x3 x4) =
+  [||LConstant.Mul <$> $$(qqExpM x1) <*> $$(qqExpM x2) <*> $$(qqExpM x3) <*> $$(qqExpM x4)||]
+qqConstantE (A.FMul' x1 x2) =
+  [||LConstant.FMul <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.UDiv' x1 x2 x3) =
+  [||LConstant.UDiv <$> $$(qqExpM x1) <*> $$(qqExpM x2) <*> $$(qqExpM x3)||]
+qqConstantE (A.SDiv' x1 x2 x3) =
+  [||LConstant.SDiv <$> $$(qqExpM x1) <*> $$(qqExpM x2) <*> $$(qqExpM x3)||]
+qqConstantE (A.FDiv' x1 x2) =
+ [||LConstant.FDiv <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.URem' x1 x2) =
+  [||LConstant.URem <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.SRem' x1 x2) =
+  [||LConstant.SRem <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.FRem' x1 x2) =
+ [||LConstant.FRem <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.Shl' x1 x2 x3 x4) =
+  [||LConstant.Shl <$> $$(qqExpM x1) <*> $$(qqExpM x2) <*> $$(qqExpM x3) <*> $$(qqExpM x4)||]
+qqConstantE (A.LShr' x1 x2 x3) =
+  [||LConstant.LShr <$> $$(qqExpM x1) <*> $$(qqExpM x2) <*> $$(qqExpM x3)||]
+qqConstantE (A.AShr' x1 x2 x3) =
+  [||LConstant.AShr <$> $$(qqExpM x1) <*> $$(qqExpM x2) <*> $$(qqExpM x3)||]
+qqConstantE (A.And' x1 x2) =
+  [||LConstant.And <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.Or' x1 x2) =
+  [||LConstant.Or <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.Xor' x1 x2) =
+  [||LConstant.Xor <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
 qqConstantE (A.GetElementPtr' x1 x2 x3) =
   [||LConstant.GetElementPtr <$> $$(qqExpM x1) <*> $$(qqExpM x2) <*> $$(qqExpM x3)||]
+qqConstantE (A.Trunc' x1 x2) =
+  [||LConstant.Trunc <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.ZExt' x1 x2) =
+  [||LConstant.ZExt <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.SExt' x1 x2) =
+  [||LConstant.SExt <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.FPToUI' x1 x2) =
+  [||LConstant.FPToUI <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.FPToSI' x1 x2) =
+  [||LConstant.FPToSI <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.UIToFP' x1 x2) =
+  [||LConstant.UIToFP <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.SIToFP' x1 x2) =
+  [||LConstant.SIToFP <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.FPTrunc' x1 x2) =
+  [||LConstant.FPTrunc <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.FPExt' x1 x2) =
+  [||LConstant.FPExt <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
 qqConstantE (A.PtrToInt' x1 x2) =
   [||LConstant.PtrToInt <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.IntToPtr' x1 x2) =
+  [||LConstant.IntToPtr <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.BitCast' x1 x2) =
+  [||LConstant.BitCast <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.AddrSpaceCast' x1 x2) =
+  [||LConstant.AddrSpaceCast <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.ICmp' x1 x2 x3) =
+  [||LConstant.ICmp <$> $$(qqExpM x1) <*> $$(qqExpM x2) <*> $$(qqExpM x3)||]
+qqConstantE (A.FCmp' x1 x2 x3) =
+  [||LConstant.FCmp <$> $$(qqExpM x1) <*> $$(qqExpM x2) <*> $$(qqExpM x3)||]
+qqConstantE (A.Select' x1 x2 x3) =
+  [||LConstant.Select <$> $$(qqExpM x1) <*> $$(qqExpM x2) <*> $$(qqExpM x3)||]
+qqConstantE (A.ExtractElement' x1 x2) =
+  [||LConstant.ExtractElement <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.InsertElement' x1 x2 x3) =
+  [||LConstant.InsertElement <$> $$(qqExpM x1) <*> $$(qqExpM x2) <*> $$(qqExpM x3)||]
+qqConstantE (A.ShuffleVector' x1 x2 x3) =
+  [||LConstant.ShuffleVector <$> $$(qqExpM x1) <*> $$(qqExpM x2) <*> $$(qqExpM x3)||]
+qqConstantE (A.ExtractValue' x1 x2) =
+  [||LConstant.ExtractValue <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.InsertValue' x1 x2 x3) =
+  [||LConstant.InsertValue <$> $$(qqExpM x1) <*> $$(qqExpM x2) <*> $$(qqExpM x3)||]
 
 qqNameE :: Conversion A.Name L.Name
 qqNameE (A.Name x1) =

--- a/src/LLVM/Quote/Base.hs
+++ b/src/LLVM/Quote/Base.hs
@@ -42,6 +42,7 @@ import qualified LLVM.AST as L
 import qualified LLVM.AST.Constant as L
   (Constant(Int, Float, Null, Struct, Array, Vector,
             Undef, BlockAddress, GlobalReference))
+import qualified LLVM.AST.Constant as LConstant
 import qualified LLVM.AST.Float as L
 import qualified LLVM.AST.InlineAssembly as L
 import qualified LLVM.AST.DataLayout as L
@@ -615,6 +616,12 @@ qqConstantE (A.GlobalReference x1 x2) =
   [||L.GlobalReference <$> $$(qqExpM x1)<*> $$(qqExpM x2)||]
 qqConstantE (A.AntiConstant s) =
   unsafeTExpCoerce [|$(antiVarE s) >>= (return . toConstant)|]
+qqConstantE (A.Add' x1 x2 x3 x4) =
+  [||LConstant.Add <$> $$(qqExpM x1) <*> $$(qqExpM x2) <*> $$(qqExpM x3) <*> $$(qqExpM x4)||]
+qqConstantE (A.FAdd' x1 x2) =
+  [||LConstant.FAdd <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.BitCast' x1 x2) =
+  [||LConstant.BitCast <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
 
 qqNameE :: Conversion A.Name L.Name
 qqNameE (A.Name x1) =

--- a/src/LLVM/Quote/Base.hs
+++ b/src/LLVM/Quote/Base.hs
@@ -624,6 +624,8 @@ qqConstantE (A.BitCast' x1 x2) =
   [||LConstant.BitCast <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
 qqConstantE (A.GetElementPtr' x1 x2 x3) =
   [||LConstant.GetElementPtr <$> $$(qqExpM x1) <*> $$(qqExpM x2) <*> $$(qqExpM x3)||]
+qqConstantE (A.PtrToInt' x1 x2) =
+  [||LConstant.PtrToInt <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
 
 qqNameE :: Conversion A.Name L.Name
 qqNameE (A.Name x1) =

--- a/src/LLVM/Quote/Base.hs
+++ b/src/LLVM/Quote/Base.hs
@@ -622,6 +622,8 @@ qqConstantE (A.FAdd' x1 x2) =
   [||LConstant.FAdd <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
 qqConstantE (A.BitCast' x1 x2) =
   [||LConstant.BitCast <$> $$(qqExpM x1) <*> $$(qqExpM x2)||]
+qqConstantE (A.GetElementPtr' x1 x2 x3) =
+  [||LConstant.GetElementPtr <$> $$(qqExpM x1) <*> $$(qqExpM x2) <*> $$(qqExpM x3)||]
 
 qqNameE :: Conversion A.Name L.Name
 qqNameE (A.Name x1) =

--- a/src/LLVM/Quote/Parser/Parser.y
+++ b/src/LLVM/Quote/Parser/Parser.y
@@ -338,18 +338,47 @@ constantIndices :
 
 {- Constant expressions -}
 {- from https://llvm.org/docs/LangRef.html#constant-expressions -}
-{- TODO: Implement other constant expressions -}
 constantExpression :
-    'add' nsw nuw '(' tConstant ',' tConstant ')'                { A.Add' $2 $3 $5 $7 }
-  | 'fadd' '(' tConstant ',' tConstant ')'                       { A.FAdd' $3 $5 }
-  | 'sub' nsw nuw '(' tConstant ',' tConstant ')'                { A.Sub' $2 $3 $5 $7 }
-  | 'fsub' '(' tConstant ',' tConstant ')'                       { A.FSub' $3 $5 }
-  | 'mul' nsw nuw '(' tConstant ',' tConstant ')'                { A.Mul' $2 $3 $5 $7 }
-  | 'fmul' '(' tConstant ',' tConstant ')'                       { A.FMul' $3 $5 }
-  | 'udiv' exact '(' tConstant ',' tConstant ')'                 { A.UDiv' $2 $4 $6 }
-  | 'ptrtoint' '(' tConstant 'to' type ')'                       { A.PtrToInt' $3 $5 }
-  | 'bitcast' '(' tConstant 'to' type ')'                        { A.BitCast' $3 $5 }
-  | 'getelementptr' inBounds '(' tConstant constantIndices ')'   { A.GetElementPtr' $2 $4 (rev $5) }
+    'add' nsw nuw '(' tConstant ',' tConstant ')'                  { A.Add' $2 $3 $5 $7 }
+  | 'fadd' '(' tConstant ',' tConstant ')'                         { A.FAdd' $3 $5 }
+  | 'sub' nsw nuw '(' tConstant ',' tConstant ')'                  { A.Sub' $2 $3 $5 $7 }
+  | 'fsub' '(' tConstant ',' tConstant ')'                         { A.FSub' $3 $5 }
+  | 'mul' nsw nuw '(' tConstant ',' tConstant ')'                  { A.Mul' $2 $3 $5 $7 }
+  | 'fmul' '(' tConstant ',' tConstant ')'                         { A.FMul' $3 $5 }
+  | 'udiv' exact '(' tConstant ',' tConstant ')'                   { A.UDiv' $2 $4 $6 }
+  | 'sdiv' exact '(' tConstant ',' tConstant ')'                   { A.SDiv' $2 $4 $6 }
+  | 'fdiv' '(' tConstant ',' tConstant ')'                         { A.FDiv' $3 $5 }
+  | 'urem' '(' tConstant ',' tConstant ')'                         { A.URem' $3 $5 }
+  | 'srem' '(' tConstant ',' tConstant ')'                         { A.SRem' $3 $5 }
+  | 'frem' '(' tConstant ',' tConstant ')'                         { A.FRem' $3 $5 }
+  | 'shl' nsw nuw '(' tConstant ',' tConstant ')'                  { A.Shl' $2 $3 $5 $7 }
+  | 'lshr' exact '(' tConstant ',' tConstant ')'                   { A.LShr' $2 $4 $6 }
+  | 'ashr' exact '(' tConstant ',' tConstant ')'                   { A.AShr' $2 $4 $6 }
+  | 'and' '(' tConstant ',' tConstant ')'                          { A.And' $3 $5 }
+  | 'or' '(' tConstant ',' tConstant ')'                           { A.Or' $3 $5 }
+  | 'xor' '(' tConstant ',' tConstant ')'                          { A.Xor' $3 $5 }
+  | 'getelementptr' inBounds '(' tConstant constantIndices ')'     { A.GetElementPtr' $2 $4 (rev $5) }
+  | 'trunc' '(' tConstant 'to' type ')'                            { A.Trunc' $3 $5 }
+  | 'zext' '(' tConstant 'to' type ')'                             { A.ZExt' $3 $5 }
+  | 'sext' '(' tConstant 'to' type ')'                             { A.SExt' $3 $5 }
+  | 'fptoui' '(' tConstant 'to' type ')'                           { A.FPToUI' $3 $5 }
+  | 'fptosi' '(' tConstant 'to' type ')'                           { A.FPToSI' $3 $5 }
+  | 'uitofp' '(' tConstant 'to' type ')'                           { A.UIToFP' $3 $5 }
+  | 'sitofp' '(' tConstant 'to' type ')'                           { A.SIToFP' $3 $5 }
+  | 'fptrunc' '(' tConstant 'to' type ')'                          { A.FPTrunc' $3 $5 }
+  | 'fpext' '(' tConstant 'to' type ')'                            { A.FPExt' $3 $5 }
+  | 'ptrtoint' '(' tConstant 'to' type ')'                         { A.PtrToInt' $3 $5 }
+  | 'inttoptr' '(' tConstant 'to' type ')'                         { A.IntToPtr' $3 $5 }
+  | 'bitcast' '(' tConstant 'to' type ')'                          { A.BitCast' $3 $5 }
+  | 'addrspacecast' '(' tConstant 'to' type ')'                    { A.AddrSpaceCast' $3 $5 }
+  | 'icmp'  intP '(' tConstant ',' tConstant ')'                   { A.ICmp' $2 $4 $6 }
+  | 'fcmp'  fpP '(' tConstant ',' tConstant ')'                    { A.FCmp' $2 $4 $6 }
+  | 'select' '(' tConstant ',' tConstant ',' tConstant ')'         { A.Select' $3 $5 $7 }
+  | 'extractelement' '(' tConstant ',' tConstant ')'               { A.ExtractElement' $3 $5 }
+  | 'insertelement' '(' tConstant ',' tConstant ',' tConstant ')'  { A.InsertElement' $3 $5 $7 }
+  | 'shufflevector' '(' tConstant ',' tConstant ',' tConstant ')'  { A.ShuffleVector' $3 $5 $7 }
+  | 'extractvalue' '(' tConstant ',' idxs ')'                      { A.ExtractValue' $3 (rev $5) }
+  | 'insertvalue' '(' tConstant ',' tConstant ',' idxs ')'         { A.InsertValue' $3 $5 (rev $7) }
 
 constantList :: { RevList A.Constant }
 constantList :

--- a/src/LLVM/Quote/Parser/Parser.y
+++ b/src/LLVM/Quote/Parser/Parser.y
@@ -342,6 +342,7 @@ constantIndices :
 constantExpression :
     'add' nsw nuw '(' tConstant ',' tConstant ')'                { A.Add' $2 $3 $5 $7 }
   | 'fadd' '(' tConstant ',' tConstant ')'                       { A.FAdd' $3 $5 }
+  | 'ptrtoint' '(' tConstant 'to' type ')'                       { A.PtrToInt' $3 $5 }
   | 'bitcast' '(' tConstant 'to' type ')'                        { A.BitCast' $3 $5 }
   | 'getelementptr' inBounds '(' tConstant constantIndices ')'   { A.GetElementPtr' $2 $4 (rev $5) }
 

--- a/src/LLVM/Quote/Parser/Parser.y
+++ b/src/LLVM/Quote/Parser/Parser.y
@@ -342,6 +342,10 @@ constantIndices :
 constantExpression :
     'add' nsw nuw '(' tConstant ',' tConstant ')'                { A.Add' $2 $3 $5 $7 }
   | 'fadd' '(' tConstant ',' tConstant ')'                       { A.FAdd' $3 $5 }
+  | 'sub' nsw nuw '(' tConstant ',' tConstant ')'                { A.Sub' $2 $3 $5 $7 }
+  | 'fsub' '(' tConstant ',' tConstant ')'                       { A.FSub' $3 $5 }
+  | 'mul' nsw nuw '(' tConstant ',' tConstant ')'                { A.Mul' $2 $3 $5 $7 }
+  | 'fmul' '(' tConstant ',' tConstant ')'                       { A.FMul' $3 $5 }
   | 'ptrtoint' '(' tConstant 'to' type ')'                       { A.PtrToInt' $3 $5 }
   | 'bitcast' '(' tConstant 'to' type ')'                        { A.BitCast' $3 $5 }
   | 'getelementptr' inBounds '(' tConstant constantIndices ')'   { A.GetElementPtr' $2 $4 (rev $5) }

--- a/src/LLVM/Quote/Parser/Parser.y
+++ b/src/LLVM/Quote/Parser/Parser.y
@@ -330,13 +330,20 @@ mConstant :
     {- empty -}            { \_ -> Nothing }
   | constant               { Just . $1 }
 
+constantIndices :: { RevList A.Constant }
+constantIndices :
+    {- empty -}                     { RNil }
+  | constantIndices ',' tConstant   { RCons $3 $1 }
+
+
 {- Constant expressions -}
 {- from https://llvm.org/docs/LangRef.html#constant-expressions -}
 {- TODO: Implement other constant expressions -}
 constantExpression :
-    'add' nsw nuw '(' tConstant ',' tConstant ')'    { A.Add' $2 $3 $5 $7 }
-  | 'fadd' '(' tConstant ',' tConstant ')'           { A.FAdd' $3 $5 }
-  | 'bitcast' '(' tConstant 'to' type ')'            { A.BitCast' $3 $5 }
+    'add' nsw nuw '(' tConstant ',' tConstant ')'                { A.Add' $2 $3 $5 $7 }
+  | 'fadd' '(' tConstant ',' tConstant ')'                       { A.FAdd' $3 $5 }
+  | 'bitcast' '(' tConstant 'to' type ')'                        { A.BitCast' $3 $5 }
+  | 'getelementptr' inBounds '(' tConstant constantIndices ')'   { A.GetElementPtr' $2 $4 (rev $5) }
 
 constantList :: { RevList A.Constant }
 constantList :

--- a/src/LLVM/Quote/Parser/Parser.y
+++ b/src/LLVM/Quote/Parser/Parser.y
@@ -346,6 +346,7 @@ constantExpression :
   | 'fsub' '(' tConstant ',' tConstant ')'                       { A.FSub' $3 $5 }
   | 'mul' nsw nuw '(' tConstant ',' tConstant ')'                { A.Mul' $2 $3 $5 $7 }
   | 'fmul' '(' tConstant ',' tConstant ')'                       { A.FMul' $3 $5 }
+  | 'udiv' exact '(' tConstant ',' tConstant ')'                 { A.UDiv' $2 $4 $6 }
   | 'ptrtoint' '(' tConstant 'to' type ')'                       { A.PtrToInt' $3 $5 }
   | 'bitcast' '(' tConstant 'to' type ')'                        { A.BitCast' $3 $5 }
   | 'getelementptr' inBounds '(' tConstant constantIndices ')'   { A.GetElementPtr' $2 $4 (rev $5) }

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -70,18 +70,18 @@ instructions =
   --   -- ashr
   -- , [lli|call void @myfunc2(i32 ashr (i32 1, i32 2))|]
   -- , [lli|call void @myfunc2(i32 ashr exact (i32 1, i32 2))|]
-    -- and
-  , [lli|call void @myfunc2(i32 and (i32 1, i32 2))|]
-    -- or
-  , [lli|call void @myfunc2(i32 or (i32 1, i32 2))|]
-    -- xor
-  , [lli|call void @myfunc2(i32 xor (i32 1, i32 2))|]
-    -- trunc
-  , [lli|call void @myfunc4(i8 trunc (i32 257 to i8))|]
-    -- zext
-  , [lli|call void @myfunc2(i32 zext (i8 2 to i32))|]
-    -- sext
-  , [lli|call void @myfunc2(i32 zext (i8 2 to i32))|]
+  --   -- and
+  -- , [lli|call void @myfunc2(i32 and (i32 1, i32 2))|]
+  --   -- or
+  -- , [lli|call void @myfunc2(i32 or (i32 1, i32 2))|]
+  --   -- xor
+  -- , [lli|call void @myfunc2(i32 xor (i32 1, i32 2))|]
+  --   -- trunc
+  -- , [lli|call void @myfunc4(i8 trunc (i32 257 to i8))|]
+  --   -- zext
+  -- , [lli|call void @myfunc2(i32 zext (i8 2 to i32))|]
+  --   -- sext
+  -- , [lli|call void @myfunc2(i32 sext (i8 2 to i32))|]
     -- fptoui
   , [lli|call void @myfunc2(i32 fptoui (float 123.0 to i32))|]
    -- fptosi
@@ -1456,6 +1456,132 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               metadata = []
             },
             [lli|call void @myfunc2(i32 ashr exact (i32 1, i32 2))|]),
+          ("call with constant and",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.And
+                                            { C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 1
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 and (i32 1, i32 2))|]),
+          ("call with constant or",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.Or
+                                            { C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 1
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 or (i32 1, i32 2))|]),
+          ("call with constant xor",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.Xor
+                                            { C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 1
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 xor (i32 1, i32 2))|]),
+          ("call with constant trunc",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i8] False)) (Name "myfunc4"))),
+              arguments = [ (ConstantOperand C.Trunc
+                                              { C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 257
+                                                }
+                                              , C.type' = i8
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc4(i8 trunc (i32 257 to i8))|]),
+          ("call with constant zext",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.ZExt
+                                              { C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 8
+                                                , C.integerValue = 2
+                                                }
+                                              , C.type' = i32
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 zext (i8 2 to i32))|]),
+          ("call with constant sext",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.SExt
+                                              { C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 8
+                                                , C.integerValue = 2
+                                                }
+                                              , C.type' = i32
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 sext (i8 2 to i32))|]),
           ("call with constant getelementptr",
             Call {
               tailCallKind = Nothing,

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -656,7 +656,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    metadata = []
                  },
                  [lli|call void @myfunc2(i32 add nsw (i32 1, i32 2))|]),
-               ("call with constant add nsw",
+               ("call with constant add nuw",
                  Call {
                    tailCallKind = Nothing,
                    callingConvention = CC.C,
@@ -668,7 +668,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    metadata = []
                  },
                  [lli|call void @myfunc2(i32 add nuw (i32 1, i32 2))|]),
-               ("call with constant add nsw",
+               ("call with constant add nsw nuw",
                  Call {
                    tailCallKind = Nothing,
                    callingConvention = CC.C,

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -43,83 +43,6 @@ retWithName ty name = [llt|ret $type:ty $id:name|]
 retWithOp :: Type -> Operand -> Terminator
 retWithOp ty op = [llt|ret $type:ty $opr:op|]
 
-
--- TODO: Move them to more strict test
-instructions :: [Instruction]
-instructions =
-  [ undefined  
-  --  -- sdiv
-  --   [lli|call void @myfunc2(i32 sdiv (i32 4, i32 2))|]
-  -- , [lli|call void @myfunc2(i32 sdiv exact (i32 4, i32 2))|]
-  --   -- fdiv
-  -- , [lli|call void @myfunc3(float fdiv (float 1.5, float 0.5))|]
-  --   -- urem
-  -- , [lli|call void @myfunc2(i32 urem (i32 4, i32 3))|]
-  --   -- srem
-  -- , [lli|call void @myfunc2(i32 srem (i32 4, i32 3))|]
-  --   -- frem
-  -- , [lli|call void @myfunc3(float frem (float 1.5, float 0.5))|]
-  -- shl
-  -- , [lli|call void @myfunc2(i32 shl (i32 1, i32 2))|]
-  -- , [lli|call void @myfunc2(i32 shl nsw (i32 1, i32 2))|]
-  -- , [lli|call void @myfunc2(i32 shl nuw (i32 1, i32 2))|]
-  -- , [lli|call void @myfunc2(i32 shl nsw nuw (i32 1, i32 2))|]
-  --   -- lshr
-  -- , [lli|call void @myfunc2(i32 lshr (i32 1, i32 2))|]
-  -- , [lli|call void @myfunc2(i32 lshr exact (i32 1, i32 2))|]
-  --   -- ashr
-  -- , [lli|call void @myfunc2(i32 ashr (i32 1, i32 2))|]
-  -- , [lli|call void @myfunc2(i32 ashr exact (i32 1, i32 2))|]
-  --   -- and
-  -- , [lli|call void @myfunc2(i32 and (i32 1, i32 2))|]
-  --   -- or
-  -- , [lli|call void @myfunc2(i32 or (i32 1, i32 2))|]
-  --   -- xor
-  -- , [lli|call void @myfunc2(i32 xor (i32 1, i32 2))|]
-  --   -- trunc
-  -- , [lli|call void @myfunc4(i8 trunc (i32 257 to i8))|]
-  --   -- zext
-  -- , [lli|call void @myfunc2(i32 zext (i8 2 to i32))|]
-  --   -- sext
-  -- , [lli|call void @myfunc2(i32 sext (i8 2 to i32))|]
-  --   -- fptoui
-  -- , [lli|call void @myfunc2(i32 fptoui (float 123.0 to i32))|]
-  --  -- fptosi
-  -- , [lli|call void @myfunc2(i32 fptosi (float 123.0 to i32))|]
-  --   -- uitofp
-  -- , [lli|call void @myfunc3(float uitofp (i32 123 to float))|]
-  --   -- sitofp
-  -- , [lli|call void @myfunc3(float sitofp (i32 123 to float))|]
-  --   -- fptrunc
-  -- , [lli|call void @myfunc3(float fptrunc (double 123.0 to float))|]
-  --   -- fpext
-  -- , [lli|call void @myfunc5(double fpext (float 123.0 to double))|]
-  --   -- ptrtoint
-  -- , [lli|call void @myfunc2(i32 ptrtoint (i8* null to i32))|]
-  --   -- inttoptr
-  -- , [lli|call void @myfunc(i8* inttoptr (i32 4 to i8*))|]
-  --   -- addrspacecast
-  -- , [lli|call void @myfunc6(i8 addrspace(1)* addrspacecast (i32* null to i8 addrspace(1)*))|]
-  --   -- icmp
-  -- , [lli|call void @myfunc7(i1 icmp eq (i32 4, i32 1))|]
-  -- , [lli|call void @myfunc7(i1 icmp ne (i32 4, i32 1))|]
-  --   -- fcmp
-  -- , [lli|call void @myfunc7(i1 fcmp oeq (float 1.5, float 0.5))|]
-  -- , [lli|call void @myfunc7(i1 fcmp one (float 1.5, float 0.5))|]
-  --   -- select
-  -- , [lli|call void @myfunc2(i32 select (i1 false, i32 1, i32 2))|]
-  --   -- extractelement
-  -- , [lli|call void @myfunc2(i32 extractelement (<4 x i32> undef, i32 1))|]
-  --   -- insertelement
-  -- , [lli|call void @myfunc8(<5 x i32> insertelement (<5 x i32> undef, i32 35, i32 0))|]
-  --   -- shufflevector
-  -- , [lli|call void @myfunc9(<3 x i32> shufflevector (<3 x i32> undef, <3 x i32> undef, <3 x i32> <i32 0, i32 4, i32 1>))|]
-    -- extractvalue
-  , [lli|call void @myfunc2(i32 extractvalue ({i32, i8} {i32 23, i8 2}, 0))|]
-    -- insertvalue
-  , [lli|call void @myfunc10({i32, i8} insertvalue ({i32, i8} {i32 41, i8 2}, i32 23, 0))|]
-  ]
-
 tests :: TestTree
 tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
   testGroup "regular" [
@@ -1998,6 +1921,69 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               metadata = []
             },
             [lli|call void @myfunc9(<3 x i32> shufflevector (<3 x i32> undef, <3 x i32> undef, <3 x i32> <i32 0, i32 4, i32 1>))|]),
+          ("call with constant extractvalue",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ ( ConstantOperand C.ExtractValue
+                                              { C.aggregate =
+                                                C.Struct
+                                                { C.structName = Nothing
+                                                , C.isPacked = False
+                                                , C.memberValues =
+                                                  [ C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 23
+                                                    }
+                                                  , C.Int
+                                                    { C.integerBits = 8
+                                                    , C.integerValue = 2
+                                                    }
+                                                  ]
+                                                }
+                                              , C.indices' = [0]
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 extractvalue ({i32, i8} {i32 23, i8 2}, 0))|]),
+          ("call with constant insertvalue",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [StructureType {isPacked = False, elementTypes = [i32, i8]}] False)) (Name "myfunc10"))),
+              arguments = [ ( ConstantOperand C.InsertValue
+                                              { C.aggregate =
+                                                C.Struct
+                                                { C.structName = Nothing
+                                                , C.isPacked = False
+                                                , C.memberValues =
+                                                  [ C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 41
+                                                    }
+                                                  , C.Int
+                                                    { C.integerBits = 8
+                                                    , C.integerValue = 2
+                                                    }
+                                                  ]
+                                                }
+                                              , C.element =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 23
+                                                }
+                                              , C.indices' = [0]
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc10({i32, i8} insertvalue ({i32, i8} {i32 41, i8 2}, i32 23, 0))|]),
           ("call with constant getelementptr inbounds",
             Call {
               tailCallKind = Nothing,

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -692,7 +692,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    metadata = []
                  },
                  [lli|call void @myfunc3(float fadd (float 0.5, float 0.25))|]),
-               ("call with constant getelementptr inbounds",
+               ("call with constant getelementptr",
                  Call {
                    tailCallKind = Nothing,
                    callingConvention = CC.C,
@@ -704,7 +704,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    metadata = []
                  },
                  [lli|call void @myfunc(i8* getelementptr ([4 x i8]* @myglobal_str, i32 0, i32 0))|]),
-               ("call with constant getelementptr",
+               ("call with constant getelementptr inbounds",
                 Call {
                   tailCallKind = Nothing,
                   callingConvention = CC.C,

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -650,20 +650,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.Add
-                                            { C.nsw = True
-                                            , C.nuw = False
-                                            , C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 1
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.Add
+                                              { C.nsw = True
+                                              , C.nuw = False
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -675,20 +675,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.Add
-                                            { C.nsw = False
-                                            , C.nuw = True
-                                            , C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 1
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.Add
+                                              { C.nsw = False
+                                              , C.nuw = True
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -700,20 +700,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.Add
-                                            { C.nsw = True
-                                            , C.nuw = True
-                                            , C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 1
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.Add
+                                              { C.nsw = True
+                                              , C.nuw = True
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -725,16 +725,16 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
-              arguments = [ (ConstantOperand C.FAdd
-                                            { C.operand0 =
-                                              C.Float
-                                              { C.floatValue = Float.Single 0.5
-                                              }
-                                            , C.operand1 =
-                                              C.Float
-                                              { C.floatValue = Float.Single 0.25
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.FAdd
+                                              { C.operand0 =
+                                                C.Float
+                                                { C.floatValue = Float.Single 0.5
+                                                }
+                                              , C.operand1 =
+                                                C.Float
+                                                { C.floatValue = Float.Single 0.25
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -746,20 +746,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.Sub
-                                            { C.nsw = False
-                                            , C.nuw = False
-                                            , C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 1
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.Sub
+                                              { C.nsw = False
+                                              , C.nuw = False
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -771,20 +771,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.Sub
-                                            { C.nsw = True
-                                            , C.nuw = False
-                                            , C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 1
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.Sub
+                                              { C.nsw = True
+                                              , C.nuw = False
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -796,20 +796,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.Sub
-                                            { C.nsw = False
-                                            , C.nuw = True
-                                            , C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 1
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.Sub
+                                              { C.nsw = False
+                                              , C.nuw = True
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -821,20 +821,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.Sub
-                                            { C.nsw = True
-                                            , C.nuw = True
-                                            , C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 1
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.Sub
+                                              { C.nsw = True
+                                              , C.nuw = True
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -846,7 +846,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
-              arguments = [ (ConstantOperand C.FSub
+              arguments = [ ( ConstantOperand C.FSub
                                               { C.operand0 =
                                                 C.Float
                                                 { C.floatValue = Float.Single 0.5
@@ -867,7 +867,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.Mul
+              arguments = [ ( ConstantOperand C.Mul
                                               { C.nsw = False
                                               , C.nuw = False
                                               , C.operand0 =
@@ -892,20 +892,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.Mul
-                                            { C.nsw = True
-                                            , C.nuw = False
-                                            , C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 1
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.Mul
+                                              { C.nsw = True
+                                              , C.nuw = False
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -917,20 +917,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.Mul
-                                            { C.nsw = False
-                                            , C.nuw = True
-                                            , C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 1
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.Mul
+                                              { C.nsw = False
+                                              , C.nuw = True
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -942,20 +942,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.Mul
-                                            { C.nsw = True
-                                            , C.nuw = True
-                                            , C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 1
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.Mul
+                                              { C.nsw = True
+                                              , C.nuw = True
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -967,16 +967,16 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
-              arguments = [ (ConstantOperand C.FMul
-                                            { C.operand0 =
-                                              C.Float
-                                              { C.floatValue = Float.Single 0.5
-                                              }
-                                            , C.operand1 =
-                                              C.Float
-                                              { C.floatValue = Float.Single 0.25
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.FMul
+                                              { C.operand0 =
+                                                C.Float
+                                                { C.floatValue = Float.Single 0.5
+                                                }
+                                              , C.operand1 =
+                                                C.Float
+                                                { C.floatValue = Float.Single 0.25
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -988,7 +988,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.UDiv
+              arguments = [ ( ConstantOperand C.UDiv
                                               { C.exact = False
                                               , C.operand0 =
                                                 C.Int
@@ -1012,19 +1012,19 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.UDiv
-                                            { C.exact = True
-                                            , C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 4
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.UDiv
+                                              { C.exact = True
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 4
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -1036,19 +1036,19 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.SDiv
-                                            { C.exact = False
-                                            , C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 4
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.SDiv
+                                              { C.exact = False
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 4
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -1060,19 +1060,19 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.SDiv
-                                            { C.exact = True
-                                            , C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 4
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.SDiv
+                                              { C.exact = True
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 4
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -1084,7 +1084,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
-              arguments = [ (ConstantOperand C.FDiv
+              arguments = [ ( ConstantOperand C.FDiv
                                               { C.operand0 =
                                                 C.Float
                                                 { C.floatValue = Float.Single 1.5
@@ -1105,18 +1105,18 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.URem
-                                            { C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 4
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 3
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.URem
+                                              { C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 4
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 3
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -1128,18 +1128,18 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.SRem
-                                            { C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 4
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 3
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.SRem
+                                              { C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 4
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 3
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -1151,7 +1151,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
-              arguments = [ (ConstantOperand C.FRem
+              arguments = [ ( ConstantOperand C.FRem
                                               { C.operand0 =
                                                 C.Float
                                                 { C.floatValue = Float.Single 1.5
@@ -1172,20 +1172,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.Shl
-                                            { C.nsw = False
-                                            , C.nuw = False
-                                            , C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 1
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.Shl
+                                              { C.nsw = False
+                                              , C.nuw = False
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -1197,7 +1197,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.Shl
+              arguments = [ ( ConstantOperand C.Shl
                                               { C.nsw = True
                                               , C.nuw = False
                                               , C.operand0 =
@@ -1222,13 +1222,13 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.Shl
+              arguments = [ ( ConstantOperand C.Shl
                                               { C.nsw = False
                                               , C.nuw = True
                                               , C.operand0 =
                                                 C.Int
                                                 { C.integerBits = 32
-                                                , C.integerValue = 1
+                                              , C.integerValue = 1
                                                 }
                                               , C.operand1 =
                                                 C.Int
@@ -1247,7 +1247,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.Shl
+              arguments = [ ( ConstantOperand C.Shl
                                               { C.nsw = True
                                               , C.nuw = True
                                               , C.operand0 =
@@ -1272,19 +1272,19 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.LShr
-                                            { C.exact = False
-                                            , C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 1
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.LShr
+                                              { C.exact = False
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -1296,19 +1296,19 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.LShr
-                                            { C.exact = True
-                                            , C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 1
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.LShr
+                                              { C.exact = True
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -1320,19 +1320,19 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.AShr
-                                            { C.exact = False
-                                            , C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 1
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.AShr
+                                              { C.exact = False
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -1344,19 +1344,19 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.AShr
-                                            { C.exact = True
-                                            , C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 1
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.AShr
+                                              { C.exact = True
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -1368,18 +1368,18 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.And
-                                            { C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 1
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.And
+                                              { C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -1391,18 +1391,18 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.Or
-                                            { C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 1
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.Or
+                                              { C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -1414,18 +1414,18 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.Xor
-                                            { C.operand0 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 1
-                                              }
-                                            , C.operand1 =
-                                              C.Int
-                                              { C.integerBits = 32
-                                              , C.integerValue = 2
-                                              }
-                                            }, [])
+              arguments = [ ( ConstantOperand C.Xor
+                                              { C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -1437,27 +1437,27 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
-              arguments = [ (ConstantOperand C.GetElementPtr
-                                            { C.inBounds = False
-                                            , C.address =
-                                              C.GlobalReference
-                                                (ptr
-                                                    ArrayType
-                                                    { nArrayElements = 4
-                                                    , elementType = i8
-                                                    })
-                                                (Name "myglobal_str")
-                                            , C.indices =
-                                              [ C.Int
-                                                { C.integerBits = 32
-                                                , C.integerValue = 0
-                                                }
-                                              , C.Int
-                                                { C.integerBits = 32
-                                                , C.integerValue = 0
-                                                }
-                                              ]
-                                            }, [])
+              arguments = [ ( ConstantOperand C.GetElementPtr
+                                              { C.inBounds = False
+                                              , C.address =
+                                                C.GlobalReference
+                                                  (ptr
+                                                      ArrayType
+                                                      { nArrayElements = 4
+                                                      , elementType = i8
+                                                      })
+                                                  (Name "myglobal_str")
+                                              , C.indices =
+                                                [ C.Int
+                                                  { C.integerBits = 32
+                                                  , C.integerValue = 0
+                                                  }
+                                                , C.Int
+                                                  { C.integerBits = 32
+                                                  , C.integerValue = 0
+                                                  }
+                                                ]
+                                              }, [])
                           ],
               functionAttributes = [],
               metadata = []
@@ -1469,7 +1469,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
-              arguments = [ (ConstantOperand C.GetElementPtr
+              arguments = [ ( ConstantOperand C.GetElementPtr
                                               { C.inBounds = True
                                               , C.address =
                                                 C.GlobalReference
@@ -1501,7 +1501,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i8] False)) (Name "myfunc4"))),
-              arguments = [ (ConstantOperand C.Trunc
+              arguments = [ ( ConstantOperand C.Trunc
                                               { C.operand0 =
                                                 C.Int
                                                 { C.integerBits = 32
@@ -1520,7 +1520,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.ZExt
+              arguments = [ ( ConstantOperand C.ZExt
                                               { C.operand0 =
                                                 C.Int
                                                 { C.integerBits = 8
@@ -1539,7 +1539,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.SExt
+              arguments = [ ( ConstantOperand C.SExt
                                               { C.operand0 =
                                                 C.Int
                                                 { C.integerBits = 8
@@ -1558,7 +1558,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.FPToUI
+              arguments = [ ( ConstantOperand C.FPToUI
                                               { C.operand0 =
                                                 C.Float
                                                 { C.floatValue = Float.Single 123.0
@@ -1576,7 +1576,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.FPToSI
+              arguments = [ ( ConstantOperand C.FPToSI
                                               { C.operand0 =
                                                 C.Float
                                                 { C.floatValue = Float.Single 123.0
@@ -1594,7 +1594,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
-              arguments = [ (ConstantOperand C.UIToFP
+              arguments = [ ( ConstantOperand C.UIToFP
                                               { C.operand0 =
                                                 C.Int
                                                 { C.integerBits = 32
@@ -1613,7 +1613,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
-              arguments = [ (ConstantOperand C.SIToFP
+              arguments = [ ( ConstantOperand C.SIToFP
                                               { C.operand0 =
                                                 C.Int
                                                 { C.integerBits = 32
@@ -1632,7 +1632,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
-              arguments = [ (ConstantOperand C.FPTrunc
+              arguments = [ ( ConstantOperand C.FPTrunc
                                               { C.operand0 =
                                                 C.Float
                                                 { C.floatValue = Float.Double 123.0
@@ -1650,7 +1650,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [double] False)) (Name "myfunc5"))),
-              arguments = [ (ConstantOperand C.FPExt
+              arguments = [ ( ConstantOperand C.FPExt
                                               { C.operand0 =
                                                 C.Float
                                                 { C.floatValue = Float.Single 123.0
@@ -1668,7 +1668,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.PtrToInt
+              arguments = [ ( ConstantOperand C.PtrToInt
                                               { C.operand0 = C.GlobalReference (ptr i8) (Name "myptr")
                                               , C.type' = i32
                                               }, [])
@@ -1683,7 +1683,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               callingConvention = CC.C,
               returnAttributes = [],
               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
-              arguments = [ (ConstantOperand C.IntToPtr
+              arguments = [ ( ConstantOperand C.IntToPtr
                                               { C.operand0 =
                                                 C.Int
                                                 { C.integerBits = 32

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -684,857 +684,857 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
              metadata = []
            },
            [lli|call void @0(i32 %0, float %1, i32* %2, i64 %3, i1 %4, <2 x i32> %5, { i32, i32 } %6)|]),
-           ("call with constant bitcast",
-             Call {
-               tailCallKind = Nothing,
-               callingConvention = CC.C,
-               returnAttributes = [],
-               function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
-               arguments = [ ( ConstantOperand
-                                 C.BitCast
-                                  { C.operand0 = (C.GlobalReference (ptr i1) (Name "myglobal"))
-                                  , C.type' = (ptr i8)
-                                  }
-                             , [])
-                           ],
-               functionAttributes = [],
-               metadata = []
-             },
-             [lli|call void @myfunc(i8* bitcast (i1* @myglobal to i8*))|]),
-             ("call with nested constant bitcast",
-               Call {
-                 tailCallKind = Nothing,
-                 callingConvention = CC.C,
-                 returnAttributes = [],
-                 function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
-                 arguments = [ (ConstantOperand (C.BitCast (C.BitCast (C.GlobalReference (ptr i1) (Name "myglobal")) (ptr (IntegerType 3))) (ptr i8)), [])
-                             ],
-                 functionAttributes = [],
-                 metadata = []
-               },
-               [lli|call void @myfunc(i8* bitcast (i3* bitcast (i1* @myglobal to i3*) to i8*))|]),
-             ("call with constant add",
-               Call {
-                 tailCallKind = Nothing,
-                 callingConvention = CC.C,
-                 returnAttributes = [],
-                 function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                 arguments = [ (ConstantOperand C.Add
-                                                { C.nsw = False
-                                                , C.nuw = False
-                                                , C.operand0 =
-                                                  C.Int
+          ("call with constant bitcast",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
+              arguments = [ ( ConstantOperand
+                                C.BitCast
+                                { C.operand0 = (C.GlobalReference (ptr i1) (Name "myglobal"))
+                                , C.type' = (ptr i8)
+                                }
+                            , [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc(i8* bitcast (i1* @myglobal to i8*))|]),
+          ("call with nested constant bitcast",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
+              arguments = [ (ConstantOperand (C.BitCast (C.BitCast (C.GlobalReference (ptr i1) (Name "myglobal")) (ptr (IntegerType 3))) (ptr i8)), [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc(i8* bitcast (i3* bitcast (i1* @myglobal to i3*) to i8*))|]),
+          ("call with constant add",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.Add
+                                            { C.nsw = False
+                                            , C.nuw = False
+                                            , C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 1
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 add (i32 1, i32 2))|]),
+          ("call with constant add nsw",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.Add
+                                            { C.nsw = True
+                                            , C.nuw = False
+                                            , C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 1
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 add nsw (i32 1, i32 2))|]),
+          ("call with constant add nuw",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.Add
+                                            { C.nsw = False
+                                            , C.nuw = True
+                                            , C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 1
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 add nuw (i32 1, i32 2))|]),
+          ("call with constant add nsw nuw",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.Add
+                                            { C.nsw = True
+                                            , C.nuw = True
+                                            , C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 1
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 add nsw nuw (i32 1, i32 2))|]),
+          ("call with constant fadd",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
+              arguments = [ (ConstantOperand C.FAdd
+                                            { C.operand0 =
+                                              C.Float
+                                              { C.floatValue = Float.Single 0.5
+                                              }
+                                            , C.operand1 =
+                                              C.Float
+                                              { C.floatValue = Float.Single 0.25
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc3(float fadd (float 0.5, float 0.25))|]),
+          ("call with constant sub",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.Sub
+                                            { C.nsw = False
+                                            , C.nuw = False
+                                            , C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 1
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 sub (i32 1, i32 2))|]),
+          ("call with constant sub nsw",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.Sub
+                                            { C.nsw = True
+                                            , C.nuw = False
+                                            , C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 1
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 sub nsw (i32 1, i32 2))|]),
+          ("call with constant sub nuw",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.Sub
+                                            { C.nsw = False
+                                            , C.nuw = True
+                                            , C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 1
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 sub nuw (i32 1, i32 2))|]),
+          ("call with constant sub nsw nuw",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.Sub
+                                            { C.nsw = True
+                                            , C.nuw = True
+                                            , C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 1
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 sub nsw nuw (i32 1, i32 2))|]),
+          ("call with constant fsub",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
+              arguments = [ (ConstantOperand C.FSub
+                                              { C.operand0 =
+                                                C.Float
+                                                { C.floatValue = Float.Single 0.5
+                                                }
+                                              , C.operand1 =
+                                                C.Float
+                                                { C.floatValue = Float.Single 0.25
+                                                }
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc3(float fsub (float 0.5, float 0.25))|]),
+          ("call with constant mul",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.Mul
+                                              { C.nsw = False
+                                              , C.nuw = False
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 mul (i32 1, i32 2))|]),
+          ("call with constant mul nsw",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.Mul
+                                            { C.nsw = True
+                                            , C.nuw = False
+                                            , C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 1
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 mul nsw (i32 1, i32 2))|]),
+          ("call with constant mul nuw",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.Mul
+                                            { C.nsw = False
+                                            , C.nuw = True
+                                            , C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 1
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 mul nuw (i32 1, i32 2))|]),
+          ("call with constant mul nsw nuw",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.Mul
+                                            { C.nsw = True
+                                            , C.nuw = True
+                                            , C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 1
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 mul nsw nuw (i32 1, i32 2))|]),
+          ("call with constant fmul",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
+              arguments = [ (ConstantOperand C.FMul
+                                            { C.operand0 =
+                                              C.Float
+                                              { C.floatValue = Float.Single 0.5
+                                              }
+                                            , C.operand1 =
+                                              C.Float
+                                              { C.floatValue = Float.Single 0.25
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc3(float fmul (float 0.5, float 0.25))|]),
+          ("call with constant udiv",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.UDiv
+                                              { C.exact = False
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 4
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 udiv (i32 4, i32 2))|]),
+          ("call with constant udiv exact",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.UDiv
+                                            { C.exact = True
+                                            , C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 4
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 udiv exact (i32 4, i32 2))|]),
+          ("call with constant sdiv",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.SDiv
+                                            { C.exact = False
+                                            , C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 4
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 sdiv (i32 4, i32 2))|]),
+          ("call with constant sdiv exact",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.SDiv
+                                            { C.exact = True
+                                            , C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 4
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 sdiv exact (i32 4, i32 2))|]),
+          ("call with constant fdiv",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
+              arguments = [ (ConstantOperand C.FDiv
+                                              { C.operand0 =
+                                                C.Float
+                                                { C.floatValue = Float.Single 1.5
+                                                }
+                                              , C.operand1 =
+                                                C.Float
+                                                { C.floatValue = Float.Single 0.5
+                                                }
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc3(float fdiv (float 1.5, float 0.5))|]),
+          ("call with constant urem",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.URem
+                                            { C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 4
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 3
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 urem (i32 4, i32 3))|]),
+          ("call with constant urem",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.SRem
+                                            { C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 4
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 3
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 srem (i32 4, i32 3))|]),
+          ("call with constant frem",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
+              arguments = [ (ConstantOperand C.FRem
+                                              { C.operand0 =
+                                                C.Float
+                                                { C.floatValue = Float.Single 1.5
+                                                }
+                                              , C.operand1 =
+                                                C.Float
+                                                { C.floatValue = Float.Single 0.5
+                                                }
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc3(float frem (float 1.5, float 0.5))|]),
+          ("call with constant shl",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.Shl
+                                            { C.nsw = False
+                                            , C.nuw = False
+                                            , C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 1
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 shl (i32 1, i32 2))|]),
+          ("call with constant shl nsw",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.Shl
+                                              { C.nsw = True
+                                              , C.nuw = False
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 shl nsw (i32 1, i32 2))|]),
+          ("call with constant shl nuw",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.Shl
+                                              { C.nsw = False
+                                              , C.nuw = True
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 shl nuw (i32 1, i32 2))|]),
+          ("call with constant shl nsw nuw",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.Shl
+                                              { C.nsw = True
+                                              , C.nuw = True
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 shl nsw nuw (i32 1, i32 2))|]),
+          ("call with constant lshr",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.LShr
+                                            { C.exact = False
+                                            , C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 1
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 lshr (i32 1, i32 2))|]),
+          ("call with constant lshr exact",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.LShr
+                                            { C.exact = True
+                                            , C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 1
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 lshr exact (i32 1, i32 2))|]),
+          ("call with constant ashr",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.AShr
+                                            { C.exact = False
+                                            , C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 1
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 ashr (i32 1, i32 2))|]),
+          ("call with constant ashr exact",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.AShr
+                                            { C.exact = True
+                                            , C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 1
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 ashr exact (i32 1, i32 2))|]),
+          ("call with constant getelementptr",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
+              arguments = [ (ConstantOperand C.GetElementPtr
+                                            { C.inBounds = False
+                                            , C.address =
+                                              C.GlobalReference
+                                                (ptr
+                                                    ArrayType
+                                                    { nArrayElements = 4
+                                                    , elementType = i8
+                                                    })
+                                                (Name "myglobal_str")
+                                            , C.indices =
+                                              [ C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 0
+                                                }
+                                              , C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 0
+                                                }
+                                              ]
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc(i8* getelementptr ([4 x i8]* @myglobal_str, i32 0, i32 0))|]),
+          ("call with constant getelementptr inbounds",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
+              arguments = [ (ConstantOperand C.GetElementPtr
+                                              { C.inBounds = True
+                                              , C.address =
+                                                C.GlobalReference
+                                                  (ptr
+                                                    ArrayType
+                                                    { nArrayElements = 4
+                                                    , elementType = i8
+                                                    })
+                                                  (Name "myglobal_str")
+                                              , C.indices =
+                                                [ C.Int
                                                   { C.integerBits = 32
-                                                  , C.integerValue = 1
+                                                  , C.integerValue = 0
                                                   }
-                                                , C.operand1 =
-                                                  C.Int
+                                                , C.Int
                                                   { C.integerBits = 32
-                                                  , C.integerValue = 2
+                                                  , C.integerValue = 0
                                                   }
-                                                }, [])
-                             ],
-                 functionAttributes = [],
-                 metadata = []
-               },
-               [lli|call void @myfunc2(i32 add (i32 1, i32 2))|]),
-               ("call with constant add nsw",
-                 Call {
-                   tailCallKind = Nothing,
-                   callingConvention = CC.C,
-                   returnAttributes = [],
-                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand C.Add
-                                                  { C.nsw = True
-                                                  , C.nuw = False
-                                                  , C.operand0 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 1
-                                                    }
-                                                  , C.operand1 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 2
-                                                    }
-                                                  }, [])
-                               ],
-                   functionAttributes = [],
-                   metadata = []
-                 },
-                 [lli|call void @myfunc2(i32 add nsw (i32 1, i32 2))|]),
-               ("call with constant add nuw",
-                 Call {
-                   tailCallKind = Nothing,
-                   callingConvention = CC.C,
-                   returnAttributes = [],
-                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand C.Add
-                                                  { C.nsw = False
-                                                  , C.nuw = True
-                                                  , C.operand0 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 1
-                                                    }
-                                                  , C.operand1 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 2
-                                                    }
-                                                  }, [])
-                               ],
-                   functionAttributes = [],
-                   metadata = []
-                 },
-                 [lli|call void @myfunc2(i32 add nuw (i32 1, i32 2))|]),
-               ("call with constant add nsw nuw",
-                 Call {
-                   tailCallKind = Nothing,
-                   callingConvention = CC.C,
-                   returnAttributes = [],
-                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand C.Add
-                                                  { C.nsw = True
-                                                  , C.nuw = True
-                                                  , C.operand0 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 1
-                                                    }
-                                                  , C.operand1 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 2
-                                                    }
-                                                  }, [])
-                               ],
-                   functionAttributes = [],
-                   metadata = []
-                 },
-                 [lli|call void @myfunc2(i32 add nsw nuw (i32 1, i32 2))|]),
-               ("call with constant fadd",
-                 Call {
-                   tailCallKind = Nothing,
-                   callingConvention = CC.C,
-                   returnAttributes = [],
-                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
-                   arguments = [ (ConstantOperand C.FAdd
-                                                  { C.operand0 =
-                                                    C.Float
-                                                    { C.floatValue = Float.Single 0.5
-                                                    }
-                                                  , C.operand1 =
-                                                    C.Float
-                                                    { C.floatValue = Float.Single 0.25
-                                                    }
-                                                  }, [])
-                               ],
-                   functionAttributes = [],
-                   metadata = []
-                 },
-                 [lli|call void @myfunc3(float fadd (float 0.5, float 0.25))|]),
-               ("call with constant sub",
-                 Call {
-                   tailCallKind = Nothing,
-                   callingConvention = CC.C,
-                   returnAttributes = [],
-                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand C.Sub
-                                                  { C.nsw = False
-                                                  , C.nuw = False
-                                                  , C.operand0 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 1
-                                                    }
-                                                  , C.operand1 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 2
-                                                    }
-                                                  }, [])
-                               ],
-                   functionAttributes = [],
-                   metadata = []
-                 },
-                 [lli|call void @myfunc2(i32 sub (i32 1, i32 2))|]),
-               ("call with constant sub nsw",
-                 Call {
-                   tailCallKind = Nothing,
-                   callingConvention = CC.C,
-                   returnAttributes = [],
-                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand C.Sub
-                                                  { C.nsw = True
-                                                  , C.nuw = False
-                                                  , C.operand0 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 1
-                                                    }
-                                                  , C.operand1 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 2
-                                                    }
-                                                  }, [])
-                               ],
-                   functionAttributes = [],
-                   metadata = []
-                 },
-                 [lli|call void @myfunc2(i32 sub nsw (i32 1, i32 2))|]),
-               ("call with constant sub nuw",
-                 Call {
-                   tailCallKind = Nothing,
-                   callingConvention = CC.C,
-                   returnAttributes = [],
-                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand C.Sub
-                                                  { C.nsw = False
-                                                  , C.nuw = True
-                                                  , C.operand0 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 1
-                                                    }
-                                                  , C.operand1 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 2
-                                                    }
-                                                  }, [])
-                               ],
-                   functionAttributes = [],
-                   metadata = []
-                 },
-                 [lli|call void @myfunc2(i32 sub nuw (i32 1, i32 2))|]),
-               ("call with constant sub nsw nuw",
-                 Call {
-                   tailCallKind = Nothing,
-                   callingConvention = CC.C,
-                   returnAttributes = [],
-                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand C.Sub
-                                                  { C.nsw = True
-                                                  , C.nuw = True
-                                                  , C.operand0 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 1
-                                                    }
-                                                  , C.operand1 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 2
-                                                    }
-                                                  }, [])
-                               ],
-                   functionAttributes = [],
-                   metadata = []
-                 },
-                 [lli|call void @myfunc2(i32 sub nsw nuw (i32 1, i32 2))|]),
-               ("call with constant fsub",
-                Call {
-                  tailCallKind = Nothing,
-                  callingConvention = CC.C,
-                  returnAttributes = [],
-                  function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
-                  arguments = [ (ConstantOperand C.FSub
-                                                 { C.operand0 =
-                                                   C.Float
-                                                   { C.floatValue = Float.Single 0.5
-                                                   }
-                                                 , C.operand1 =
-                                                   C.Float
-                                                   { C.floatValue = Float.Single 0.25
-                                                   }
-                                                 }, [])
-                              ],
-                  functionAttributes = [],
-                  metadata = []
-                },
-                [lli|call void @myfunc3(float fsub (float 0.5, float 0.25))|]),
-               ("call with constant mul",
-                  Call {
-                    tailCallKind = Nothing,
-                    callingConvention = CC.C,
-                    returnAttributes = [],
-                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                    arguments = [ (ConstantOperand C.Mul
-                                                   { C.nsw = False
-                                                   , C.nuw = False
-                                                   , C.operand0 =
-                                                     C.Int
-                                                     { C.integerBits = 32
-                                                     , C.integerValue = 1
-                                                     }
-                                                   , C.operand1 =
-                                                     C.Int
-                                                     { C.integerBits = 32
-                                                     , C.integerValue = 2
-                                                     }
-                                                   }, [])
-                                ],
-                    functionAttributes = [],
-                    metadata = []
-                  },
-                  [lli|call void @myfunc2(i32 mul (i32 1, i32 2))|]),
-               ("call with constant mul nsw",
-                 Call {
-                   tailCallKind = Nothing,
-                   callingConvention = CC.C,
-                   returnAttributes = [],
-                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand C.Mul
-                                                  { C.nsw = True
-                                                  , C.nuw = False
-                                                  , C.operand0 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 1
-                                                    }
-                                                  , C.operand1 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 2
-                                                    }
-                                                  }, [])
-                               ],
-                   functionAttributes = [],
-                   metadata = []
-                 },
-                 [lli|call void @myfunc2(i32 mul nsw (i32 1, i32 2))|]),
-               ("call with constant mul nuw",
-                 Call {
-                   tailCallKind = Nothing,
-                   callingConvention = CC.C,
-                   returnAttributes = [],
-                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand C.Mul
-                                                  { C.nsw = False
-                                                  , C.nuw = True
-                                                  , C.operand0 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 1
-                                                    }
-                                                  , C.operand1 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 2
-                                                    }
-                                                  }, [])
-                               ],
-                   functionAttributes = [],
-                   metadata = []
-                 },
-                 [lli|call void @myfunc2(i32 mul nuw (i32 1, i32 2))|]),
-               ("call with constant mul nsw nuw",
-                 Call {
-                   tailCallKind = Nothing,
-                   callingConvention = CC.C,
-                   returnAttributes = [],
-                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand C.Mul
-                                                  { C.nsw = True
-                                                  , C.nuw = True
-                                                  , C.operand0 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 1
-                                                    }
-                                                  , C.operand1 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 2
-                                                    }
-                                                  }, [])
-                               ],
-                   functionAttributes = [],
-                   metadata = []
-                 },
-                 [lli|call void @myfunc2(i32 mul nsw nuw (i32 1, i32 2))|]),
-               ("call with constant fmul",
-                 Call {
-                   tailCallKind = Nothing,
-                   callingConvention = CC.C,
-                   returnAttributes = [],
-                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
-                   arguments = [ (ConstantOperand C.FMul
-                                                  { C.operand0 =
-                                                    C.Float
-                                                    { C.floatValue = Float.Single 0.5
-                                                    }
-                                                  , C.operand1 =
-                                                    C.Float
-                                                    { C.floatValue = Float.Single 0.25
-                                                    }
-                                                  }, [])
-                               ],
-                   functionAttributes = [],
-                   metadata = []
-                 },
-                 [lli|call void @myfunc3(float fmul (float 0.5, float 0.25))|]),
-               ("call with constant udiv",
-                Call {
-                  tailCallKind = Nothing,
-                  callingConvention = CC.C,
-                  returnAttributes = [],
-                  function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                  arguments = [ (ConstantOperand C.UDiv
-                                                 { C.exact = False
-                                                 , C.operand0 =
-                                                   C.Int
-                                                   { C.integerBits = 32
-                                                   , C.integerValue = 4
-                                                   }
-                                                 , C.operand1 =
-                                                   C.Int
-                                                   { C.integerBits = 32
-                                                   , C.integerValue = 2
-                                                   }
-                                                 }, [])
-                              ],
-                  functionAttributes = [],
-                  metadata = []
-                },
-                [lli|call void @myfunc2(i32 udiv (i32 4, i32 2))|]),
-               ("call with constant udiv exact",
-                 Call {
-                   tailCallKind = Nothing,
-                   callingConvention = CC.C,
-                   returnAttributes = [],
-                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand C.UDiv
-                                                  { C.exact = True
-                                                  , C.operand0 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 4
-                                                    }
-                                                  , C.operand1 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 2
-                                                    }
-                                                  }, [])
-                               ],
-                   functionAttributes = [],
-                   metadata = []
-                 },
-                 [lli|call void @myfunc2(i32 udiv exact (i32 4, i32 2))|]),
-               ("call with constant sdiv",
-                 Call {
-                   tailCallKind = Nothing,
-                   callingConvention = CC.C,
-                   returnAttributes = [],
-                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand C.SDiv
-                                                  { C.exact = False
-                                                  , C.operand0 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 4
-                                                    }
-                                                  , C.operand1 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 2
-                                                    }
-                                                  }, [])
-                               ],
-                   functionAttributes = [],
-                   metadata = []
-                 },
-                 [lli|call void @myfunc2(i32 sdiv (i32 4, i32 2))|]),
-               ("call with constant sdiv exact",
-                 Call {
-                   tailCallKind = Nothing,
-                   callingConvention = CC.C,
-                   returnAttributes = [],
-                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand C.SDiv
-                                                  { C.exact = True
-                                                  , C.operand0 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 4
-                                                    }
-                                                  , C.operand1 =
-                                                    C.Int
-                                                    { C.integerBits = 32
-                                                    , C.integerValue = 2
-                                                    }
-                                                  }, [])
-                               ],
-                   functionAttributes = [],
-                   metadata = []
-                 },
-                [lli|call void @myfunc2(i32 sdiv exact (i32 4, i32 2))|]),
-               ("call with constant fdiv",
-                  Call {
-                    tailCallKind = Nothing,
-                    callingConvention = CC.C,
-                    returnAttributes = [],
-                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
-                    arguments = [ (ConstantOperand C.FDiv
-                                                   { C.operand0 =
-                                                     C.Float
-                                                     { C.floatValue = Float.Single 1.5
-                                                     }
-                                                   , C.operand1 =
-                                                     C.Float
-                                                     { C.floatValue = Float.Single 0.5
-                                                     }
-                                                   }, [])
-                                ],
-                    functionAttributes = [],
-                    metadata = []
-                  },
-                  [lli|call void @myfunc3(float fdiv (float 1.5, float 0.5))|]),
-                  ("call with constant urem",
-                    Call {
-                      tailCallKind = Nothing,
-                      callingConvention = CC.C,
-                      returnAttributes = [],
-                      function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                      arguments = [ (ConstantOperand C.URem
-                                                    { C.operand0 =
-                                                      C.Int
-                                                      { C.integerBits = 32
-                                                      , C.integerValue = 4
-                                                      }
-                                                    , C.operand1 =
-                                                      C.Int
-                                                      { C.integerBits = 32
-                                                      , C.integerValue = 3
-                                                      }
-                                                    }, [])
-                                  ],
-                      functionAttributes = [],
-                      metadata = []
-                    },
-                    [lli|call void @myfunc2(i32 urem (i32 4, i32 3))|]),
-                    ("call with constant urem",
-                      Call {
-                        tailCallKind = Nothing,
-                        callingConvention = CC.C,
-                        returnAttributes = [],
-                        function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                        arguments = [ (ConstantOperand C.SRem
-                                                      { C.operand0 =
-                                                        C.Int
-                                                        { C.integerBits = 32
-                                                        , C.integerValue = 4
-                                                        }
-                                                      , C.operand1 =
-                                                        C.Int
-                                                        { C.integerBits = 32
-                                                        , C.integerValue = 3
-                                                        }
-                                                      }, [])
-                                    ],
-                        functionAttributes = [],
-                        metadata = []
-                      },
-                      [lli|call void @myfunc2(i32 srem (i32 4, i32 3))|]),
-                ("call with constant frem",
-                  Call {
-                    tailCallKind = Nothing,
-                    callingConvention = CC.C,
-                    returnAttributes = [],
-                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
-                    arguments = [ (ConstantOperand C.FRem
-                                                   { C.operand0 =
-                                                     C.Float
-                                                     { C.floatValue = Float.Single 1.5
-                                                     }
-                                                   , C.operand1 =
-                                                     C.Float
-                                                     { C.floatValue = Float.Single 0.5
-                                                     }
-                                                   }, [])
-                                ],
-                    functionAttributes = [],
-                    metadata = []
-                  },
-                  [lli|call void @myfunc3(float frem (float 1.5, float 0.5))|]),
-                  ("call with constant shl",
-                    Call {
-                      tailCallKind = Nothing,
-                      callingConvention = CC.C,
-                      returnAttributes = [],
-                      function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                      arguments = [ (ConstantOperand C.Shl
-                                                    { C.nsw = False
-                                                    , C.nuw = False
-                                                    , C.operand0 =
-                                                      C.Int
-                                                      { C.integerBits = 32
-                                                      , C.integerValue = 1
-                                                      }
-                                                    , C.operand1 =
-                                                      C.Int
-                                                      { C.integerBits = 32
-                                                      , C.integerValue = 2
-                                                      }
-                                                    }, [])
-                                  ],
-                      functionAttributes = [],
-                      metadata = []
-                    },
-                    [lli|call void @myfunc2(i32 shl (i32 1, i32 2))|]),
-                ("call with constant shl nsw",
-                  Call {
-                    tailCallKind = Nothing,
-                    callingConvention = CC.C,
-                    returnAttributes = [],
-                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                    arguments = [ (ConstantOperand C.Shl
-                                                    { C.nsw = True
-                                                    , C.nuw = False
-                                                    , C.operand0 =
-                                                      C.Int
-                                                      { C.integerBits = 32
-                                                      , C.integerValue = 1
-                                                      }
-                                                    , C.operand1 =
-                                                      C.Int
-                                                      { C.integerBits = 32
-                                                      , C.integerValue = 2
-                                                      }
-                                                    }, [])
-                                ],
-                    functionAttributes = [],
-                    metadata = []
-                  },
-                  [lli|call void @myfunc2(i32 shl nsw (i32 1, i32 2))|]),
-                ("call with constant shl nuw",
-                  Call {
-                    tailCallKind = Nothing,
-                    callingConvention = CC.C,
-                    returnAttributes = [],
-                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                    arguments = [ (ConstantOperand C.Shl
-                                                    { C.nsw = False
-                                                    , C.nuw = True
-                                                    , C.operand0 =
-                                                      C.Int
-                                                      { C.integerBits = 32
-                                                      , C.integerValue = 1
-                                                      }
-                                                    , C.operand1 =
-                                                      C.Int
-                                                      { C.integerBits = 32
-                                                      , C.integerValue = 2
-                                                      }
-                                                    }, [])
-                                ],
-                    functionAttributes = [],
-                    metadata = []
-                  },
-                  [lli|call void @myfunc2(i32 shl nuw (i32 1, i32 2))|]),
-                ("call with constant shl nsw nuw",
-                  Call {
-                    tailCallKind = Nothing,
-                    callingConvention = CC.C,
-                    returnAttributes = [],
-                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                    arguments = [ (ConstantOperand C.Shl
-                                                    { C.nsw = True
-                                                    , C.nuw = True
-                                                    , C.operand0 =
-                                                      C.Int
-                                                      { C.integerBits = 32
-                                                      , C.integerValue = 1
-                                                      }
-                                                    , C.operand1 =
-                                                      C.Int
-                                                      { C.integerBits = 32
-                                                      , C.integerValue = 2
-                                                      }
-                                                    }, [])
-                                ],
-                    functionAttributes = [],
-                    metadata = []
-                  },
-                  [lli|call void @myfunc2(i32 shl nsw nuw (i32 1, i32 2))|]),
-                  ("call with constant lshr",
-                    Call {
-                      tailCallKind = Nothing,
-                      callingConvention = CC.C,
-                      returnAttributes = [],
-                      function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                      arguments = [ (ConstantOperand C.LShr
-                                                    { C.exact = False
-                                                    , C.operand0 =
-                                                      C.Int
-                                                      { C.integerBits = 32
-                                                      , C.integerValue = 1
-                                                      }
-                                                    , C.operand1 =
-                                                      C.Int
-                                                      { C.integerBits = 32
-                                                      , C.integerValue = 2
-                                                      }
-                                                    }, [])
-                                  ],
-                      functionAttributes = [],
-                      metadata = []
-                    },
-                    [lli|call void @myfunc2(i32 lshr (i32 1, i32 2))|]),
-                  ("call with constant lshr exact",
-                    Call {
-                      tailCallKind = Nothing,
-                      callingConvention = CC.C,
-                      returnAttributes = [],
-                      function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                      arguments = [ (ConstantOperand C.LShr
-                                                    { C.exact = True
-                                                    , C.operand0 =
-                                                      C.Int
-                                                      { C.integerBits = 32
-                                                      , C.integerValue = 1
-                                                      }
-                                                    , C.operand1 =
-                                                      C.Int
-                                                      { C.integerBits = 32
-                                                      , C.integerValue = 2
-                                                      }
-                                                    }, [])
-                                  ],
-                      functionAttributes = [],
-                      metadata = []
-                    },
-                    [lli|call void @myfunc2(i32 lshr exact (i32 1, i32 2))|]),
-                    ("call with constant ashr",
-                      Call {
-                        tailCallKind = Nothing,
-                        callingConvention = CC.C,
-                        returnAttributes = [],
-                        function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                        arguments = [ (ConstantOperand C.AShr
-                                                      { C.exact = False
-                                                      , C.operand0 =
-                                                        C.Int
-                                                        { C.integerBits = 32
-                                                        , C.integerValue = 1
-                                                        }
-                                                      , C.operand1 =
-                                                        C.Int
-                                                        { C.integerBits = 32
-                                                        , C.integerValue = 2
-                                                        }
-                                                      }, [])
-                                    ],
-                        functionAttributes = [],
-                        metadata = []
-                      },
-                      [lli|call void @myfunc2(i32 ashr (i32 1, i32 2))|]),
-                    ("call with constant ashr exact",
-                      Call {
-                        tailCallKind = Nothing,
-                        callingConvention = CC.C,
-                        returnAttributes = [],
-                        function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                        arguments = [ (ConstantOperand C.AShr
-                                                      { C.exact = True
-                                                      , C.operand0 =
-                                                        C.Int
-                                                        { C.integerBits = 32
-                                                        , C.integerValue = 1
-                                                        }
-                                                      , C.operand1 =
-                                                        C.Int
-                                                        { C.integerBits = 32
-                                                        , C.integerValue = 2
-                                                        }
-                                                      }, [])
-                                    ],
-                        functionAttributes = [],
-                        metadata = []
-                      },
-                      [lli|call void @myfunc2(i32 ashr exact (i32 1, i32 2))|]),
-                ("call with constant getelementptr",
-                 Call {
-                   tailCallKind = Nothing,
-                   callingConvention = CC.C,
-                   returnAttributes = [],
-                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
-                   arguments = [ (ConstantOperand C.GetElementPtr
-                                                  { C.inBounds = False
-                                                  , C.address =
-                                                    C.GlobalReference
-                                                      (ptr
-                                                         ArrayType
-                                                         { nArrayElements = 4
-                                                         , elementType = i8
-                                                         })
-                                                      (Name "myglobal_str")
-                                                  , C.indices =
-                                                    [ C.Int
-                                                      { C.integerBits = 32
-                                                      , C.integerValue = 0
-                                                      }
-                                                    , C.Int
-                                                      { C.integerBits = 32
-                                                      , C.integerValue = 0
-                                                      }
-                                                    ]
-                                                  }, [])
-                               ],
-                   functionAttributes = [],
-                   metadata = []
-                 },
-                 [lli|call void @myfunc(i8* getelementptr ([4 x i8]* @myglobal_str, i32 0, i32 0))|]),
-               ("call with constant getelementptr inbounds",
-                Call {
-                  tailCallKind = Nothing,
-                  callingConvention = CC.C,
-                  returnAttributes = [],
-                  function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
-                  arguments = [ (ConstantOperand C.GetElementPtr
-                                                 { C.inBounds = True
-                                                 , C.address =
-                                                   C.GlobalReference
-                                                     (ptr
-                                                        ArrayType
-                                                        { nArrayElements = 4
-                                                        , elementType = i8
-                                                        })
-                                                     (Name "myglobal_str")
-                                                 , C.indices =
-                                                   [ C.Int
-                                                     { C.integerBits = 32
-                                                     , C.integerValue = 0
-                                                     }
-                                                   , C.Int
-                                                     { C.integerBits = 32
-                                                     , C.integerValue = 0
-                                                     }
-                                                   ]
-                                                 }, [])
-                              ],
-                  functionAttributes = [],
-                  metadata = []
-                },
-                [lli|call void @myfunc(i8* getelementptr inbounds ([4 x i8]* @myglobal_str, i32 0, i32 0))|]),
-               ("call with constant ptrtoint",
-                Call {
-                  tailCallKind = Nothing,
-                  callingConvention = CC.C,
-                  returnAttributes = [],
-                  function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                  arguments = [ (ConstantOperand C.PtrToInt
-                                                 { C.operand0 = C.GlobalReference (ptr i8) (Name "myptr")
-                                                 , C.type' = i32
-                                                 }, [])
-                              ],
-                  functionAttributes = [],
-                  metadata = []
-                },
-                [lli|call void @myfunc2(i32 ptrtoint (i8* @myptr to i32))|])
+                                                ]
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc(i8* getelementptr inbounds ([4 x i8]* @myglobal_str, i32 0, i32 0))|]),
+          ("call with constant ptrtoint",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.PtrToInt
+                                              { C.operand0 = C.GlobalReference (ptr i8) (Name "myptr")
+                                              , C.type' = i32
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 ptrtoint (i8* @myptr to i32))|])
          ]
    ],
 

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -812,6 +812,30 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    metadata = []
                  },
                  [lli|call void @myfunc3(float fmul (float 0.5, float 0.25))|]),
+               ("call with constant udiv",
+                Call {
+                  tailCallKind = Nothing,
+                  callingConvention = CC.C,
+                  returnAttributes = [],
+                  function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                  arguments = [ (ConstantOperand (C.UDiv False (C.Int 32 4) (C.Int 32 2)), [])
+                              ],
+                  functionAttributes = [],
+                  metadata = []
+                },
+                [lli|call void @myfunc2(i32 udiv (i32 4, i32 2))|]),
+               ("call with constant udiv exact",
+                 Call {
+                   tailCallKind = Nothing,
+                   callingConvention = CC.C,
+                   returnAttributes = [],
+                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                   arguments = [ (ConstantOperand (C.UDiv True (C.Int 32 4) (C.Int 32 2)), [])
+                               ],
+                   functionAttributes = [],
+                   metadata = []
+                 },
+                 [lli|call void @myfunc2(i32 udiv exact (i32 4, i32 2))|]),
                ("call with constant getelementptr",
                  Call {
                    tailCallKind = Nothing,

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -64,12 +64,12 @@ instructions =
   -- , [lli|call void @myfunc2(i32 shl nsw (i32 1, i32 2))|]
   -- , [lli|call void @myfunc2(i32 shl nuw (i32 1, i32 2))|]
   -- , [lli|call void @myfunc2(i32 shl nsw nuw (i32 1, i32 2))|]
-    -- lshr
-  , [lli|call void @myfunc2(i32 lshr (i32 1, i32 2))|]
-  , [lli|call void @myfunc2(i32 lshr exact (i32 1, i32 2))|]
-    -- ashr
-  , [lli|call void @myfunc2(i32 ashr (i32 1, i32 2))|]
-  , [lli|call void @myfunc2(i32 ashr exact (i32 1, i32 2))|]
+  --   -- lshr
+  -- , [lli|call void @myfunc2(i32 lshr (i32 1, i32 2))|]
+  -- , [lli|call void @myfunc2(i32 lshr exact (i32 1, i32 2))|]
+  --   -- ashr
+  -- , [lli|call void @myfunc2(i32 ashr (i32 1, i32 2))|]
+  -- , [lli|call void @myfunc2(i32 ashr exact (i32 1, i32 2))|]
     -- and
   , [lli|call void @myfunc2(i32 and (i32 1, i32 2))|]
     -- or
@@ -1171,7 +1171,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    functionAttributes = [],
                    metadata = []
                  },
-                  [lli|call void @myfunc2(i32 sdiv exact (i32 4, i32 2))|]),
+                [lli|call void @myfunc2(i32 sdiv exact (i32 4, i32 2))|]),
                ("call with constant fdiv",
                   Call {
                     tailCallKind = Nothing,
@@ -1360,6 +1360,102 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                     metadata = []
                   },
                   [lli|call void @myfunc2(i32 shl nsw nuw (i32 1, i32 2))|]),
+                  ("call with constant lshr",
+                    Call {
+                      tailCallKind = Nothing,
+                      callingConvention = CC.C,
+                      returnAttributes = [],
+                      function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                      arguments = [ (ConstantOperand C.LShr
+                                                    { C.exact = False
+                                                    , C.operand0 =
+                                                      C.Int
+                                                      { C.integerBits = 32
+                                                      , C.integerValue = 1
+                                                      }
+                                                    , C.operand1 =
+                                                      C.Int
+                                                      { C.integerBits = 32
+                                                      , C.integerValue = 2
+                                                      }
+                                                    }, [])
+                                  ],
+                      functionAttributes = [],
+                      metadata = []
+                    },
+                    [lli|call void @myfunc2(i32 lshr (i32 1, i32 2))|]),
+                  ("call with constant lshr exact",
+                    Call {
+                      tailCallKind = Nothing,
+                      callingConvention = CC.C,
+                      returnAttributes = [],
+                      function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                      arguments = [ (ConstantOperand C.LShr
+                                                    { C.exact = True
+                                                    , C.operand0 =
+                                                      C.Int
+                                                      { C.integerBits = 32
+                                                      , C.integerValue = 1
+                                                      }
+                                                    , C.operand1 =
+                                                      C.Int
+                                                      { C.integerBits = 32
+                                                      , C.integerValue = 2
+                                                      }
+                                                    }, [])
+                                  ],
+                      functionAttributes = [],
+                      metadata = []
+                    },
+                    [lli|call void @myfunc2(i32 lshr exact (i32 1, i32 2))|]),
+                    ("call with constant ashr",
+                      Call {
+                        tailCallKind = Nothing,
+                        callingConvention = CC.C,
+                        returnAttributes = [],
+                        function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                        arguments = [ (ConstantOperand C.AShr
+                                                      { C.exact = False
+                                                      , C.operand0 =
+                                                        C.Int
+                                                        { C.integerBits = 32
+                                                        , C.integerValue = 1
+                                                        }
+                                                      , C.operand1 =
+                                                        C.Int
+                                                        { C.integerBits = 32
+                                                        , C.integerValue = 2
+                                                        }
+                                                      }, [])
+                                    ],
+                        functionAttributes = [],
+                        metadata = []
+                      },
+                      [lli|call void @myfunc2(i32 ashr (i32 1, i32 2))|]),
+                    ("call with constant ashr exact",
+                      Call {
+                        tailCallKind = Nothing,
+                        callingConvention = CC.C,
+                        returnAttributes = [],
+                        function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                        arguments = [ (ConstantOperand C.AShr
+                                                      { C.exact = True
+                                                      , C.operand0 =
+                                                        C.Int
+                                                        { C.integerBits = 32
+                                                        , C.integerValue = 1
+                                                        }
+                                                      , C.operand1 =
+                                                        C.Int
+                                                        { C.integerBits = 32
+                                                        , C.integerValue = 2
+                                                        }
+                                                      }, [])
+                                    ],
+                        functionAttributes = [],
+                        metadata = []
+                      },
+                      [lli|call void @myfunc2(i32 ashr exact (i32 1, i32 2))|]),
                 ("call with constant getelementptr",
                  Call {
                    tailCallKind = Nothing,

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -47,22 +47,23 @@ retWithOp ty op = [llt|ret $type:ty $opr:op|]
 -- TODO: Move them to more strict test
 instructions :: [Instruction]
 instructions =
-  [ -- sdiv
-    [lli|call void @myfunc2(i32 sdiv (i32 4, i32 2))|]
-  , [lli|call void @myfunc2(i32 sdiv exact (i32 4, i32 2))|]
-    -- fdiv
-  , [lli|call void @myfunc3(float fdiv (float 1.5, float 0.5))|]
-    -- urem
-  , [lli|call void @myfunc2(i32 urem (i32 4, i32 3))|]
-    -- srem
-  , [lli|call void @myfunc2(i32 srem (i32 4, i32 3))|]
-    -- frem
-  , [lli|call void @myfunc3(float frem (float 1.5, float 0.5))|]
-    -- shl
-  , [lli|call void @myfunc2(i32 shl (i32 1, i32 2))|]
-  , [lli|call void @myfunc2(i32 shl nsw (i32 1, i32 2))|]
-  , [lli|call void @myfunc2(i32 shl nuw (i32 1, i32 2))|]
-  , [lli|call void @myfunc2(i32 shl nsw nuw (i32 1, i32 2))|]
+  [ undefined  
+  --  -- sdiv
+  --   [lli|call void @myfunc2(i32 sdiv (i32 4, i32 2))|]
+  -- , [lli|call void @myfunc2(i32 sdiv exact (i32 4, i32 2))|]
+  --   -- fdiv
+  -- , [lli|call void @myfunc3(float fdiv (float 1.5, float 0.5))|]
+  --   -- urem
+  -- , [lli|call void @myfunc2(i32 urem (i32 4, i32 3))|]
+  --   -- srem
+  -- , [lli|call void @myfunc2(i32 srem (i32 4, i32 3))|]
+  --   -- frem
+  -- , [lli|call void @myfunc3(float frem (float 1.5, float 0.5))|]
+  -- shl
+  -- , [lli|call void @myfunc2(i32 shl (i32 1, i32 2))|]
+  -- , [lli|call void @myfunc2(i32 shl nsw (i32 1, i32 2))|]
+  -- , [lli|call void @myfunc2(i32 shl nuw (i32 1, i32 2))|]
+  -- , [lli|call void @myfunc2(i32 shl nsw nuw (i32 1, i32 2))|]
     -- lshr
   , [lli|call void @myfunc2(i32 lshr (i32 1, i32 2))|]
   , [lli|call void @myfunc2(i32 lshr exact (i32 1, i32 2))|]
@@ -1123,7 +1124,243 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    metadata = []
                  },
                  [lli|call void @myfunc2(i32 udiv exact (i32 4, i32 2))|]),
-               ("call with constant getelementptr",
+               ("call with constant sdiv",
+                 Call {
+                   tailCallKind = Nothing,
+                   callingConvention = CC.C,
+                   returnAttributes = [],
+                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                   arguments = [ (ConstantOperand C.SDiv
+                                                  { C.exact = False
+                                                  , C.operand0 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 4
+                                                    }
+                                                  , C.operand1 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 2
+                                                    }
+                                                  }, [])
+                               ],
+                   functionAttributes = [],
+                   metadata = []
+                 },
+                 [lli|call void @myfunc2(i32 sdiv (i32 4, i32 2))|]),
+               ("call with constant sdiv exact",
+                 Call {
+                   tailCallKind = Nothing,
+                   callingConvention = CC.C,
+                   returnAttributes = [],
+                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                   arguments = [ (ConstantOperand C.SDiv
+                                                  { C.exact = True
+                                                  , C.operand0 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 4
+                                                    }
+                                                  , C.operand1 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 2
+                                                    }
+                                                  }, [])
+                               ],
+                   functionAttributes = [],
+                   metadata = []
+                 },
+                  [lli|call void @myfunc2(i32 sdiv exact (i32 4, i32 2))|]),
+               ("call with constant fdiv",
+                  Call {
+                    tailCallKind = Nothing,
+                    callingConvention = CC.C,
+                    returnAttributes = [],
+                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
+                    arguments = [ (ConstantOperand C.FDiv
+                                                   { C.operand0 =
+                                                     C.Float
+                                                     { C.floatValue = Float.Single 1.5
+                                                     }
+                                                   , C.operand1 =
+                                                     C.Float
+                                                     { C.floatValue = Float.Single 0.5
+                                                     }
+                                                   }, [])
+                                ],
+                    functionAttributes = [],
+                    metadata = []
+                  },
+                  [lli|call void @myfunc3(float fdiv (float 1.5, float 0.5))|]),
+                  ("call with constant urem",
+                    Call {
+                      tailCallKind = Nothing,
+                      callingConvention = CC.C,
+                      returnAttributes = [],
+                      function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                      arguments = [ (ConstantOperand C.URem
+                                                    { C.operand0 =
+                                                      C.Int
+                                                      { C.integerBits = 32
+                                                      , C.integerValue = 4
+                                                      }
+                                                    , C.operand1 =
+                                                      C.Int
+                                                      { C.integerBits = 32
+                                                      , C.integerValue = 3
+                                                      }
+                                                    }, [])
+                                  ],
+                      functionAttributes = [],
+                      metadata = []
+                    },
+                    [lli|call void @myfunc2(i32 urem (i32 4, i32 3))|]),
+                    ("call with constant urem",
+                      Call {
+                        tailCallKind = Nothing,
+                        callingConvention = CC.C,
+                        returnAttributes = [],
+                        function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                        arguments = [ (ConstantOperand C.SRem
+                                                      { C.operand0 =
+                                                        C.Int
+                                                        { C.integerBits = 32
+                                                        , C.integerValue = 4
+                                                        }
+                                                      , C.operand1 =
+                                                        C.Int
+                                                        { C.integerBits = 32
+                                                        , C.integerValue = 3
+                                                        }
+                                                      }, [])
+                                    ],
+                        functionAttributes = [],
+                        metadata = []
+                      },
+                      [lli|call void @myfunc2(i32 srem (i32 4, i32 3))|]),
+                ("call with constant frem",
+                  Call {
+                    tailCallKind = Nothing,
+                    callingConvention = CC.C,
+                    returnAttributes = [],
+                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
+                    arguments = [ (ConstantOperand C.FRem
+                                                   { C.operand0 =
+                                                     C.Float
+                                                     { C.floatValue = Float.Single 1.5
+                                                     }
+                                                   , C.operand1 =
+                                                     C.Float
+                                                     { C.floatValue = Float.Single 0.5
+                                                     }
+                                                   }, [])
+                                ],
+                    functionAttributes = [],
+                    metadata = []
+                  },
+                  [lli|call void @myfunc3(float frem (float 1.5, float 0.5))|]),
+                  ("call with constant shl",
+                    Call {
+                      tailCallKind = Nothing,
+                      callingConvention = CC.C,
+                      returnAttributes = [],
+                      function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                      arguments = [ (ConstantOperand C.Shl
+                                                    { C.nsw = False
+                                                    , C.nuw = False
+                                                    , C.operand0 =
+                                                      C.Int
+                                                      { C.integerBits = 32
+                                                      , C.integerValue = 1
+                                                      }
+                                                    , C.operand1 =
+                                                      C.Int
+                                                      { C.integerBits = 32
+                                                      , C.integerValue = 2
+                                                      }
+                                                    }, [])
+                                  ],
+                      functionAttributes = [],
+                      metadata = []
+                    },
+                    [lli|call void @myfunc2(i32 shl (i32 1, i32 2))|]),
+                ("call with constant shl nsw",
+                  Call {
+                    tailCallKind = Nothing,
+                    callingConvention = CC.C,
+                    returnAttributes = [],
+                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                    arguments = [ (ConstantOperand C.Shl
+                                                    { C.nsw = True
+                                                    , C.nuw = False
+                                                    , C.operand0 =
+                                                      C.Int
+                                                      { C.integerBits = 32
+                                                      , C.integerValue = 1
+                                                      }
+                                                    , C.operand1 =
+                                                      C.Int
+                                                      { C.integerBits = 32
+                                                      , C.integerValue = 2
+                                                      }
+                                                    }, [])
+                                ],
+                    functionAttributes = [],
+                    metadata = []
+                  },
+                  [lli|call void @myfunc2(i32 shl nsw (i32 1, i32 2))|]),
+                ("call with constant shl nuw",
+                  Call {
+                    tailCallKind = Nothing,
+                    callingConvention = CC.C,
+                    returnAttributes = [],
+                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                    arguments = [ (ConstantOperand C.Shl
+                                                    { C.nsw = False
+                                                    , C.nuw = True
+                                                    , C.operand0 =
+                                                      C.Int
+                                                      { C.integerBits = 32
+                                                      , C.integerValue = 1
+                                                      }
+                                                    , C.operand1 =
+                                                      C.Int
+                                                      { C.integerBits = 32
+                                                      , C.integerValue = 2
+                                                      }
+                                                    }, [])
+                                ],
+                    functionAttributes = [],
+                    metadata = []
+                  },
+                  [lli|call void @myfunc2(i32 shl nuw (i32 1, i32 2))|]),
+                ("call with constant shl nsw nuw",
+                  Call {
+                    tailCallKind = Nothing,
+                    callingConvention = CC.C,
+                    returnAttributes = [],
+                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                    arguments = [ (ConstantOperand C.Shl
+                                                    { C.nsw = True
+                                                    , C.nuw = True
+                                                    , C.operand0 =
+                                                      C.Int
+                                                      { C.integerBits = 32
+                                                      , C.integerValue = 1
+                                                      }
+                                                    , C.operand1 =
+                                                      C.Int
+                                                      { C.integerBits = 32
+                                                      , C.integerValue = 2
+                                                      }
+                                                    }, [])
+                                ],
+                    functionAttributes = [],
+                    metadata = []
+                  },
+                  [lli|call void @myfunc2(i32 shl nsw nuw (i32 1, i32 2))|]),
+                ("call with constant getelementptr",
                  Call {
                    tailCallKind = Nothing,
                    callingConvention = CC.C,

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -710,12 +710,24 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                   callingConvention = CC.C,
                   returnAttributes = [],
                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
-                  arguments = [ (ConstantOperand (C.GetElementPtr True ((C.GlobalReference (ptr (ArrayType 4 i8)) (Name "myglobal_str"))) [C.Int 32 0, C.Int 32 0]), [])
+                  arguments = [ (ConstantOperand (C.GetElementPtr True (C.GlobalReference (ptr (ArrayType 4 i8)) (Name "myglobal_str")) [C.Int 32 0, C.Int 32 0]), [])
                               ],
                   functionAttributes = [],
                   metadata = []
                 },
-                [lli|call void @myfunc(i8* getelementptr inbounds ([4 x i8]* @myglobal_str, i32 0, i32 0))|])
+                [lli|call void @myfunc(i8* getelementptr inbounds ([4 x i8]* @myglobal_str, i32 0, i32 0))|]),
+               ("call with constant ptrtoint",
+                Call {
+                  tailCallKind = Nothing,
+                  callingConvention = CC.C,
+                  returnAttributes = [],
+                  function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                  arguments = [ (ConstantOperand (C.PtrToInt (C.GlobalReference (ptr i8) (Name "myptr")) i32), [])
+                              ],
+                  functionAttributes = [],
+                  metadata = []
+                },
+                [lli|call void @myfunc2(i32 ptrtoint (i8* @myptr to i32))|])
          ]
    ],
 

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -44,6 +44,81 @@ retWithOp :: Type -> Operand -> Terminator
 retWithOp ty op = [llt|ret $type:ty $opr:op|]
 
 
+-- TODO: Move them to more strict test
+instructions :: [Instruction]
+instructions =
+  [ -- sdiv
+    [lli|call void @myfunc2(i32 sdiv (i32 4, i32 2))|]
+  , [lli|call void @myfunc2(i32 sdiv exact (i32 4, i32 2))|]
+    -- fdiv
+  , [lli|call void @myfunc3(float fdiv (float 1.5, float 0.5))|]
+    -- urem
+  , [lli|call void @myfunc2(i32 urem (i32 4, i32 3))|]
+    -- srem
+  , [lli|call void @myfunc2(i32 srem (i32 4, i32 3))|]
+    -- frem
+  , [lli|call void @myfunc3(float frem (float 1.5, float 0.5))|]
+    -- shl
+  , [lli|call void @myfunc2(i32 shl (i32 1, i32 2))|]
+  , [lli|call void @myfunc2(i32 shl nsw (i32 1, i32 2))|]
+  , [lli|call void @myfunc2(i32 shl nuw (i32 1, i32 2))|]
+  , [lli|call void @myfunc2(i32 shl nsw nuw (i32 1, i32 2))|]
+    -- lshr
+  , [lli|call void @myfunc2(i32 lshr (i32 1, i32 2))|]
+  , [lli|call void @myfunc2(i32 lshr exact (i32 1, i32 2))|]
+    -- ashr
+  , [lli|call void @myfunc2(i32 ashr (i32 1, i32 2))|]
+  , [lli|call void @myfunc2(i32 ashr exact (i32 1, i32 2))|]
+    -- and
+  , [lli|call void @myfunc2(i32 and (i32 1, i32 2))|]
+    -- or
+  , [lli|call void @myfunc2(i32 or (i32 1, i32 2))|]
+    -- xor
+  , [lli|call void @myfunc2(i32 xor (i32 1, i32 2))|]
+    -- trunc
+  , [lli|call void @myfunc4(i8 trunc (i32 257 to i8))|]
+    -- zext
+  , [lli|call void @myfunc2(i32 zext (i8 2 to i32))|]
+    -- sext
+  , [lli|call void @myfunc2(i32 zext (i8 2 to i32))|]
+    -- fptoui
+  , [lli|call void @myfunc2(i32 fptoui (float 123.0 to i32))|]
+   -- fptosi
+  , [lli|call void @myfunc2(i32 fptosi (float 123.0 to i32))|]
+    -- uitofp
+  , [lli|call void @myfunc3(float uitofp (i32 123 to float))|]
+    -- sitofp
+  , [lli|call void @myfunc3(float sitofp (i32 123 to float))|]
+    -- fptrunc
+  , [lli|call void @myfunc3(float fptrunc (double 123.0 to float))|]
+    -- fpext
+  , [lli|call void @myfunc5(double fpext (float 123.0 to double))|]
+    -- ptrtoint
+  , [lli|call void @myfunc2(i32 ptrtoint (i8* null to i32))|]
+    -- inttoptr
+  , [lli|call void @myfunc(i8* inttoptr (i32 4 to i8*))|]
+    -- addrspacecast
+  , [lli|call void @myfunc6(i8 addrspace(1)* addrspacecast (i32* null to i8 addrspace(1)*))|]
+    -- icmp
+  , [lli|call void @myfunc7(i1 icmp eq (i32 4, i32 1))|]
+  , [lli|call void @myfunc7(i1 icmp ne (i32 4, i32 1))|]
+    -- fcmp
+  , [lli|call void @myfunc7(i1 fcmp oeq (float 1.5, float 0.5))|]
+  , [lli|call void @myfunc7(i1 fcmp one (float 1.5, float 0.5))|]
+    -- select
+  , [lli|call void @myfunc2(i32 select (i1 false, i32 1, i32 2))|]
+    -- extractelement
+  , [lli|call void @myfunc2(i32 extractelement (<4 x i32> undef, i32 1))|]
+    -- insertelement
+  , [lli|call void @myfunc8(<5 x i32> insertelement (<5 x i32> undef, i32 35, i32 0))|]
+    -- shufflevector
+  , [lli|call void @myfunc9(<3 x i32> shufflevector (<3 x i32> undef, <3 x i32> undef, <3 x i32> <i32 0, i32 4, i32 1>))|]
+    -- extractvalue
+  , [lli|call void @myfunc2(i32 extractvalue ({i32, i8} {i32 23, i8 2}, 0))|]
+    -- insertvalue
+  , [lli|call void @myfunc10({i32, i8} insertvalue ({i32, i8} {i32 41, i8 2}, i32 23, 0))|]
+  ]
+
 tests :: TestTree
 tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
   testGroup "regular" [

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -100,12 +100,12 @@ instructions =
   -- , [lli|call void @myfunc(i8* inttoptr (i32 4 to i8*))|]
   --   -- addrspacecast
   -- , [lli|call void @myfunc6(i8 addrspace(1)* addrspacecast (i32* null to i8 addrspace(1)*))|]
-    -- icmp
-  , [lli|call void @myfunc7(i1 icmp eq (i32 4, i32 1))|]
-  , [lli|call void @myfunc7(i1 icmp ne (i32 4, i32 1))|]
-    -- fcmp
-  , [lli|call void @myfunc7(i1 fcmp oeq (float 1.5, float 0.5))|]
-  , [lli|call void @myfunc7(i1 fcmp one (float 1.5, float 0.5))|]
+  --   -- icmp
+  -- , [lli|call void @myfunc7(i1 icmp eq (i32 4, i32 1))|]
+  -- , [lli|call void @myfunc7(i1 icmp ne (i32 4, i32 1))|]
+  --   -- fcmp
+  -- , [lli|call void @myfunc7(i1 fcmp oeq (float 1.5, float 0.5))|]
+  -- , [lli|call void @myfunc7(i1 fcmp one (float 1.5, float 0.5))|]
     -- select
   , [lli|call void @myfunc2(i32 select (i1 false, i32 1, i32 2))|]
     -- extractelement
@@ -1743,6 +1743,98 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               metadata = []
             },
             [lli|call void @myfunc6(i8 addrspace(1)* addrspacecast (i32* @myglobal to i8 addrspace(1)*))|]),
+          ("call with constant icmp eq",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i1] False)) (Name "myfunc7"))),
+              arguments = [ (ConstantOperand C.ICmp
+                                            { C.iPredicate = IPred.EQ
+                                            , C.operand0 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 4
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 1
+                                              }
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc7(i1 icmp eq (i32 4, i32 1))|]),
+          ("call with constant icmp ne",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i1] False)) (Name "myfunc7"))),
+              arguments = [ ( ConstantOperand C.ICmp
+                                              { C.iPredicate = IPred.NE
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 4
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc7(i1 icmp ne (i32 4, i32 1))|]),
+          ("call with constant fcmp oeq",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i1] False)) (Name "myfunc7"))),
+              arguments = [ ( ConstantOperand C.FCmp
+                                              { C.fpPredicate = FPPred.OEQ
+                                              , C.operand0 =
+                                                C.Float
+                                                { C.floatValue = Float.Single 1.5
+                                                }
+                                              , C.operand1 =
+                                                C.Float
+                                                { C.floatValue = Float.Single 0.5
+                                                }
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc7(i1 fcmp oeq (float 1.5, float 0.5))|]),
+          ("call with constant fcmp one",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i1] False)) (Name "myfunc7"))),
+              arguments = [ ( ConstantOperand C.FCmp
+                                              { C.fpPredicate = FPPred.ONE
+                                              , C.operand0 =
+                                                C.Float
+                                                { C.floatValue = Float.Single 1.5
+                                                }
+                                              , C.operand1 =
+                                                C.Float
+                                                { C.floatValue = Float.Single 0.5
+                                                }
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc7(i1 fcmp one (float 1.5, float 0.5))|]),
           ("call with constant getelementptr",
             Call {
               tailCallKind = Nothing,

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -691,7 +691,31 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    functionAttributes = [],
                    metadata = []
                  },
-                 [lli|call void @myfunc3(float fadd (float 0.5, float 0.25))|])
+                 [lli|call void @myfunc3(float fadd (float 0.5, float 0.25))|]),
+               ("call with constant getelementptr inbounds",
+                 Call {
+                   tailCallKind = Nothing,
+                   callingConvention = CC.C,
+                   returnAttributes = [],
+                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
+                   arguments = [ (ConstantOperand (C.GetElementPtr False ((C.GlobalReference (ptr (ArrayType 4 i8)) (Name "myglobal_str"))) [C.Int 32 0, C.Int 32 0]), [])
+                               ],
+                   functionAttributes = [],
+                   metadata = []
+                 },
+                 [lli|call void @myfunc(i8* getelementptr ([4 x i8]* @myglobal_str, i32 0, i32 0))|]),
+               ("call with constant getelementptr",
+                Call {
+                  tailCallKind = Nothing,
+                  callingConvention = CC.C,
+                  returnAttributes = [],
+                  function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
+                  arguments = [ (ConstantOperand (C.GetElementPtr True ((C.GlobalReference (ptr (ArrayType 4 i8)) (Name "myglobal_str"))) [C.Int 32 0, C.Int 32 0]), [])
+                              ],
+                  functionAttributes = [],
+                  metadata = []
+                },
+                [lli|call void @myfunc(i8* getelementptr inbounds ([4 x i8]* @myglobal_str, i32 0, i32 0))|])
          ]
    ],
 

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -106,14 +106,14 @@ instructions =
   --   -- fcmp
   -- , [lli|call void @myfunc7(i1 fcmp oeq (float 1.5, float 0.5))|]
   -- , [lli|call void @myfunc7(i1 fcmp one (float 1.5, float 0.5))|]
-    -- select
-  , [lli|call void @myfunc2(i32 select (i1 false, i32 1, i32 2))|]
-    -- extractelement
-  , [lli|call void @myfunc2(i32 extractelement (<4 x i32> undef, i32 1))|]
-    -- insertelement
-  , [lli|call void @myfunc8(<5 x i32> insertelement (<5 x i32> undef, i32 35, i32 0))|]
-    -- shufflevector
-  , [lli|call void @myfunc9(<3 x i32> shufflevector (<3 x i32> undef, <3 x i32> undef, <3 x i32> <i32 0, i32 4, i32 1>))|]
+  --   -- select
+  -- , [lli|call void @myfunc2(i32 select (i1 false, i32 1, i32 2))|]
+  --   -- extractelement
+  -- , [lli|call void @myfunc2(i32 extractelement (<4 x i32> undef, i32 1))|]
+  --   -- insertelement
+  -- , [lli|call void @myfunc8(<5 x i32> insertelement (<5 x i32> undef, i32 35, i32 0))|]
+  --   -- shufflevector
+  -- , [lli|call void @myfunc9(<3 x i32> shufflevector (<3 x i32> undef, <3 x i32> undef, <3 x i32> <i32 0, i32 4, i32 1>))|]
     -- extractvalue
   , [lli|call void @myfunc2(i32 extractvalue ({i32, i8} {i32 23, i8 2}, 0))|]
     -- insertvalue
@@ -1867,6 +1867,137 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               metadata = []
             },
             [lli|call void @myfunc(i8* getelementptr ([4 x i8]* @myglobal_str, i32 0, i32 0))|]),
+          ("call with constant select",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ ( ConstantOperand C.Select
+                                              { C.condition' =
+                                                C.Int
+                                                { C.integerBits = 1
+                                                , C.integerValue = 0
+                                                }
+                                              , C.trueValue =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              , C.falseValue =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 2
+                                                }
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 select (i1 false, i32 1, i32 2))|]),
+          ("call with constant extractelement",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ ( ConstantOperand C.ExtractElement
+                                              { C.vector =
+                                                C.Undef
+                                                { C.constantType =
+                                                  VectorType
+                                                  { nVectorElements = 4
+                                                  , elementType = i32
+                                                  }
+                                                }
+                                              , C.index =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 1
+                                                }
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 extractelement (<4 x i32> undef, i32 1))|]),
+          ("call with constant insertelement",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [VectorType { nVectorElements = 5, elementType = i32 }] False)) (Name "myfunc8"))),
+              arguments = [ ( ConstantOperand C.InsertElement
+                                              { C.vector =
+                                                C.Undef
+                                                { C.constantType =
+                                                  VectorType
+                                                  { nVectorElements = 5
+                                                  , elementType = i32
+                                                  }
+                                                }
+                                              , C.element =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 35
+                                                }
+                                              , C.index =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 0
+                                                }
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc8(<5 x i32> insertelement (<5 x i32> undef, i32 35, i32 0))|]),
+          ("call with constant shufflevector",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [VectorType { nVectorElements = 3, elementType = i32 }] False)) (Name "myfunc9"))),
+              arguments = [ ( ConstantOperand C.ShuffleVector
+                                              { C.operand0 =
+                                                C.Undef
+                                                { C.constantType =
+                                                  VectorType
+                                                  { nVectorElements = 3
+                                                  , elementType = i32
+                                                  }
+                                                }
+                                              , C.operand1 =
+                                                C.Undef
+                                                { C.constantType =
+                                                  VectorType
+                                                  { nVectorElements = 3
+                                                  , elementType = i32
+                                                  }
+                                                }
+                                              , C.mask =
+                                                C.Vector
+                                                { C.memberValues =
+                                                  [ C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 0
+                                                    }
+                                                  , C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 4
+                                                    }
+                                                  , C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 1
+                                                    }
+                                                  ]
+                                                }
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc9(<3 x i32> shufflevector (<3 x i32> undef, <3 x i32> undef, <3 x i32> <i32 0, i32 4, i32 1>))|]),
           ("call with constant getelementptr inbounds",
             Call {
               tailCallKind = Nothing,

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -607,18 +607,41 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
              metadata = []
            },
            [lli|call void @0(i32 %0, float %1, i32* %2, i64 %3, i1 %4, <2 x i32> %5, { i32, i32 } %6)|]),
-          ("call with nested constant bitcast",
+          ("call with nested constant expression",
             Call {
               tailCallKind = Nothing,
               callingConvention = CC.C,
               returnAttributes = [],
-              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
-              arguments = [ (ConstantOperand (C.BitCast (C.BitCast (C.GlobalReference (ptr i1) (Name "myglobal")) (ptr (IntegerType 3))) (ptr i8)), [])
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.Add
+                                            { C.nsw = False
+                                            , C.nuw = False
+                                            , C.operand0 =
+                                              C.Mul
+                                              { C.nsw = False
+                                              , C.nuw = False
+                                              , C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 5
+                                                }
+                                              , C.operand1 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 10
+                                                }
+                                              }
+                                            , C.operand1 =
+                                              C.Int
+                                              { C.integerBits = 32
+                                              , C.integerValue = 2
+                                              }
+                                            }, [])
                           ],
               functionAttributes = [],
               metadata = []
             },
-            [lli|call void @myfunc(i8* bitcast (i3* bitcast (i1* @myglobal to i3*) to i8*))|]),
+            [lli|call void @myfunc2(i32 add (i32 mul (i32 5, i32 10), i32 2))|]),
           ("call with constant add",
             Call {
               tailCallKind = Nothing,

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -689,7 +689,12 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                callingConvention = CC.C,
                returnAttributes = [],
                function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
-               arguments = [ (ConstantOperand (C.BitCast (C.GlobalReference (ptr i1) (Name "myglobal")) (ptr i8)), [])
+               arguments = [ ( ConstantOperand
+                                 C.BitCast
+                                  { C.operand0 = (C.GlobalReference (ptr i1) (Name "myglobal"))
+                                  , C.type' = (ptr i8)
+                                  }
+                             , [])
                            ],
                functionAttributes = [],
                metadata = []
@@ -713,7 +718,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                  callingConvention = CC.C,
                  returnAttributes = [],
                  function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                 arguments = [ (ConstantOperand (C.Add False False (C.Int 32 1) (C.Int 32 2)), [])
+                 arguments = [ (ConstantOperand C.Add
+                                                { C.nsw = False
+                                                , C.nuw = False
+                                                , C.operand0 =
+                                                  C.Int
+                                                  { C.integerBits = 32
+                                                  , C.integerValue = 1
+                                                  }
+                                                , C.operand1 =
+                                                  C.Int
+                                                  { C.integerBits = 32
+                                                  , C.integerValue = 2
+                                                  }
+                                                }, [])
                              ],
                  functionAttributes = [],
                  metadata = []
@@ -725,7 +743,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    callingConvention = CC.C,
                    returnAttributes = [],
                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand (C.Add True False (C.Int 32 1) (C.Int 32 2)), [])
+                   arguments = [ (ConstantOperand C.Add
+                                                  { C.nsw = True
+                                                  , C.nuw = False
+                                                  , C.operand0 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 1
+                                                    }
+                                                  , C.operand1 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 2
+                                                    }
+                                                  }, [])
                                ],
                    functionAttributes = [],
                    metadata = []
@@ -737,7 +768,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    callingConvention = CC.C,
                    returnAttributes = [],
                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand (C.Add False True (C.Int 32 1) (C.Int 32 2)), [])
+                   arguments = [ (ConstantOperand C.Add
+                                                  { C.nsw = False
+                                                  , C.nuw = True
+                                                  , C.operand0 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 1
+                                                    }
+                                                  , C.operand1 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 2
+                                                    }
+                                                  }, [])
                                ],
                    functionAttributes = [],
                    metadata = []
@@ -749,7 +793,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    callingConvention = CC.C,
                    returnAttributes = [],
                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand (C.Add True True (C.Int 32 1) (C.Int 32 2)), [])
+                   arguments = [ (ConstantOperand C.Add
+                                                  { C.nsw = True
+                                                  , C.nuw = True
+                                                  , C.operand0 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 1
+                                                    }
+                                                  , C.operand1 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 2
+                                                    }
+                                                  }, [])
                                ],
                    functionAttributes = [],
                    metadata = []
@@ -761,7 +818,16 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    callingConvention = CC.C,
                    returnAttributes = [],
                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
-                   arguments = [ (ConstantOperand (C.FAdd (C.Float (Float.Single 0.5)) (C.Float (Float.Single 0.25))), [])
+                   arguments = [ (ConstantOperand C.FAdd
+                                                  { C.operand0 =
+                                                    C.Float
+                                                    { C.floatValue = Float.Single 0.5
+                                                    }
+                                                  , C.operand1 =
+                                                    C.Float
+                                                    { C.floatValue = Float.Single 0.25
+                                                    }
+                                                  }, [])
                                ],
                    functionAttributes = [],
                    metadata = []
@@ -773,7 +839,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    callingConvention = CC.C,
                    returnAttributes = [],
                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand (C.Sub False False (C.Int 32 1) (C.Int 32 2)), [])
+                   arguments = [ (ConstantOperand C.Sub
+                                                  { C.nsw = False
+                                                  , C.nuw = False
+                                                  , C.operand0 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 1
+                                                    }
+                                                  , C.operand1 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 2
+                                                    }
+                                                  }, [])
                                ],
                    functionAttributes = [],
                    metadata = []
@@ -785,7 +864,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    callingConvention = CC.C,
                    returnAttributes = [],
                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand (C.Sub True False (C.Int 32 1) (C.Int 32 2)), [])
+                   arguments = [ (ConstantOperand C.Sub
+                                                  { C.nsw = True
+                                                  , C.nuw = False
+                                                  , C.operand0 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 1
+                                                    }
+                                                  , C.operand1 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 2
+                                                    }
+                                                  }, [])
                                ],
                    functionAttributes = [],
                    metadata = []
@@ -797,7 +889,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    callingConvention = CC.C,
                    returnAttributes = [],
                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand (C.Sub False True (C.Int 32 1) (C.Int 32 2)), [])
+                   arguments = [ (ConstantOperand C.Sub
+                                                  { C.nsw = False
+                                                  , C.nuw = True
+                                                  , C.operand0 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 1
+                                                    }
+                                                  , C.operand1 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 2
+                                                    }
+                                                  }, [])
                                ],
                    functionAttributes = [],
                    metadata = []
@@ -809,7 +914,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    callingConvention = CC.C,
                    returnAttributes = [],
                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand (C.Sub True True (C.Int 32 1) (C.Int 32 2)), [])
+                   arguments = [ (ConstantOperand C.Sub
+                                                  { C.nsw = True
+                                                  , C.nuw = True
+                                                  , C.operand0 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 1
+                                                    }
+                                                  , C.operand1 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 2
+                                                    }
+                                                  }, [])
                                ],
                    functionAttributes = [],
                    metadata = []
@@ -821,7 +939,16 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                   callingConvention = CC.C,
                   returnAttributes = [],
                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
-                  arguments = [ (ConstantOperand (C.FSub (C.Float (Float.Single 0.5)) (C.Float (Float.Single 0.25))), [])
+                  arguments = [ (ConstantOperand C.FSub
+                                                 { C.operand0 =
+                                                   C.Float
+                                                   { C.floatValue = Float.Single 0.5
+                                                   }
+                                                 , C.operand1 =
+                                                   C.Float
+                                                   { C.floatValue = Float.Single 0.25
+                                                   }
+                                                 }, [])
                               ],
                   functionAttributes = [],
                   metadata = []
@@ -833,7 +960,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                     callingConvention = CC.C,
                     returnAttributes = [],
                     function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                    arguments = [ (ConstantOperand (C.Mul False False (C.Int 32 1) (C.Int 32 2)), [])
+                    arguments = [ (ConstantOperand C.Mul
+                                                   { C.nsw = False
+                                                   , C.nuw = False
+                                                   , C.operand0 =
+                                                     C.Int
+                                                     { C.integerBits = 32
+                                                     , C.integerValue = 1
+                                                     }
+                                                   , C.operand1 =
+                                                     C.Int
+                                                     { C.integerBits = 32
+                                                     , C.integerValue = 2
+                                                     }
+                                                   }, [])
                                 ],
                     functionAttributes = [],
                     metadata = []
@@ -845,7 +985,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    callingConvention = CC.C,
                    returnAttributes = [],
                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand (C.Mul True False (C.Int 32 1) (C.Int 32 2)), [])
+                   arguments = [ (ConstantOperand C.Mul
+                                                  { C.nsw = True
+                                                  , C.nuw = False
+                                                  , C.operand0 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 1
+                                                    }
+                                                  , C.operand1 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 2
+                                                    }
+                                                  }, [])
                                ],
                    functionAttributes = [],
                    metadata = []
@@ -857,7 +1010,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    callingConvention = CC.C,
                    returnAttributes = [],
                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand (C.Mul False True (C.Int 32 1) (C.Int 32 2)), [])
+                   arguments = [ (ConstantOperand C.Mul
+                                                  { C.nsw = False
+                                                  , C.nuw = True
+                                                  , C.operand0 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 1
+                                                    }
+                                                  , C.operand1 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 2
+                                                    }
+                                                  }, [])
                                ],
                    functionAttributes = [],
                    metadata = []
@@ -869,7 +1035,20 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    callingConvention = CC.C,
                    returnAttributes = [],
                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand (C.Mul True True (C.Int 32 1) (C.Int 32 2)), [])
+                   arguments = [ (ConstantOperand C.Mul
+                                                  { C.nsw = True
+                                                  , C.nuw = True
+                                                  , C.operand0 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 1
+                                                    }
+                                                  , C.operand1 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 2
+                                                    }
+                                                  }, [])
                                ],
                    functionAttributes = [],
                    metadata = []
@@ -881,7 +1060,16 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    callingConvention = CC.C,
                    returnAttributes = [],
                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
-                   arguments = [ (ConstantOperand (C.FMul (C.Float (Float.Single 0.5)) (C.Float (Float.Single 0.25))), [])
+                   arguments = [ (ConstantOperand C.FMul
+                                                  { C.operand0 =
+                                                    C.Float
+                                                    { C.floatValue = Float.Single 0.5
+                                                    }
+                                                  , C.operand1 =
+                                                    C.Float
+                                                    { C.floatValue = Float.Single 0.25
+                                                    }
+                                                  }, [])
                                ],
                    functionAttributes = [],
                    metadata = []
@@ -893,7 +1081,19 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                   callingConvention = CC.C,
                   returnAttributes = [],
                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                  arguments = [ (ConstantOperand (C.UDiv False (C.Int 32 4) (C.Int 32 2)), [])
+                  arguments = [ (ConstantOperand C.UDiv
+                                                 { C.exact = False
+                                                 , C.operand0 =
+                                                   C.Int
+                                                   { C.integerBits = 32
+                                                   , C.integerValue = 4
+                                                   }
+                                                 , C.operand1 =
+                                                   C.Int
+                                                   { C.integerBits = 32
+                                                   , C.integerValue = 2
+                                                   }
+                                                 }, [])
                               ],
                   functionAttributes = [],
                   metadata = []
@@ -905,7 +1105,19 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    callingConvention = CC.C,
                    returnAttributes = [],
                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                   arguments = [ (ConstantOperand (C.UDiv True (C.Int 32 4) (C.Int 32 2)), [])
+                   arguments = [ (ConstantOperand C.UDiv
+                                                  { C.exact = True
+                                                  , C.operand0 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 4
+                                                    }
+                                                  , C.operand1 =
+                                                    C.Int
+                                                    { C.integerBits = 32
+                                                    , C.integerValue = 2
+                                                    }
+                                                  }, [])
                                ],
                    functionAttributes = [],
                    metadata = []
@@ -917,7 +1129,27 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    callingConvention = CC.C,
                    returnAttributes = [],
                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
-                   arguments = [ (ConstantOperand (C.GetElementPtr False ((C.GlobalReference (ptr (ArrayType 4 i8)) (Name "myglobal_str"))) [C.Int 32 0, C.Int 32 0]), [])
+                   arguments = [ (ConstantOperand C.GetElementPtr
+                                                  { C.inBounds = False
+                                                  , C.address =
+                                                    C.GlobalReference
+                                                      (ptr
+                                                         ArrayType
+                                                         { nArrayElements = 4
+                                                         , elementType = i8
+                                                         })
+                                                      (Name "myglobal_str")
+                                                  , C.indices =
+                                                    [ C.Int
+                                                      { C.integerBits = 32
+                                                      , C.integerValue = 0
+                                                      }
+                                                    , C.Int
+                                                      { C.integerBits = 32
+                                                      , C.integerValue = 0
+                                                      }
+                                                    ]
+                                                  }, [])
                                ],
                    functionAttributes = [],
                    metadata = []
@@ -929,7 +1161,27 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                   callingConvention = CC.C,
                   returnAttributes = [],
                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
-                  arguments = [ (ConstantOperand (C.GetElementPtr True (C.GlobalReference (ptr (ArrayType 4 i8)) (Name "myglobal_str")) [C.Int 32 0, C.Int 32 0]), [])
+                  arguments = [ (ConstantOperand C.GetElementPtr
+                                                 { C.inBounds = True
+                                                 , C.address =
+                                                   C.GlobalReference
+                                                     (ptr
+                                                        ArrayType
+                                                        { nArrayElements = 4
+                                                        , elementType = i8
+                                                        })
+                                                     (Name "myglobal_str")
+                                                 , C.indices =
+                                                   [ C.Int
+                                                     { C.integerBits = 32
+                                                     , C.integerValue = 0
+                                                     }
+                                                   , C.Int
+                                                     { C.integerBits = 32
+                                                     , C.integerValue = 0
+                                                     }
+                                                   ]
+                                                 }, [])
                               ],
                   functionAttributes = [],
                   metadata = []
@@ -941,7 +1193,10 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                   callingConvention = CC.C,
                   returnAttributes = [],
                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-                  arguments = [ (ConstantOperand (C.PtrToInt (C.GlobalReference (ptr i8) (Name "myptr")) i32), [])
+                  arguments = [ (ConstantOperand C.PtrToInt
+                                                 { C.operand0 = C.GlobalReference (ptr i8) (Name "myptr")
+                                                 , C.type' = i32
+                                                 }, [])
                               ],
                   functionAttributes = [],
                   metadata = []

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -1431,6 +1431,70 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               metadata = []
             },
             [lli|call void @myfunc2(i32 xor (i32 1, i32 2))|]),
+          ("call with constant getelementptr",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
+              arguments = [ (ConstantOperand C.GetElementPtr
+                                            { C.inBounds = False
+                                            , C.address =
+                                              C.GlobalReference
+                                                (ptr
+                                                    ArrayType
+                                                    { nArrayElements = 4
+                                                    , elementType = i8
+                                                    })
+                                                (Name "myglobal_str")
+                                            , C.indices =
+                                              [ C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 0
+                                                }
+                                              , C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 0
+                                                }
+                                              ]
+                                            }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc(i8* getelementptr ([4 x i8]* @myglobal_str, i32 0, i32 0))|]),
+          ("call with constant getelementptr inbounds",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
+              arguments = [ (ConstantOperand C.GetElementPtr
+                                              { C.inBounds = True
+                                              , C.address =
+                                                C.GlobalReference
+                                                  (ptr
+                                                    ArrayType
+                                                    { nArrayElements = 4
+                                                    , elementType = i8
+                                                    })
+                                                  (Name "myglobal_str")
+                                              , C.indices =
+                                                [ C.Int
+                                                  { C.integerBits = 32
+                                                  , C.integerValue = 0
+                                                  }
+                                                , C.Int
+                                                  { C.integerBits = 32
+                                                  , C.integerValue = 0
+                                                  }
+                                                ]
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc(i8* getelementptr inbounds ([4 x i8]* @myglobal_str, i32 0, i32 0))|]),
           ("call with constant trunc",
             Call {
               tailCallKind = Nothing,
@@ -1758,38 +1822,6 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               metadata = []
             },
             [lli|call void @myfunc7(i1 fcmp one (float 1.5, float 0.5))|]),
-          ("call with constant getelementptr",
-            Call {
-              tailCallKind = Nothing,
-              callingConvention = CC.C,
-              returnAttributes = [],
-              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
-              arguments = [ (ConstantOperand C.GetElementPtr
-                                            { C.inBounds = False
-                                            , C.address =
-                                              C.GlobalReference
-                                                (ptr
-                                                    ArrayType
-                                                    { nArrayElements = 4
-                                                    , elementType = i8
-                                                    })
-                                                (Name "myglobal_str")
-                                            , C.indices =
-                                              [ C.Int
-                                                { C.integerBits = 32
-                                                , C.integerValue = 0
-                                                }
-                                              , C.Int
-                                                { C.integerBits = 32
-                                                , C.integerValue = 0
-                                                }
-                                              ]
-                                            }, [])
-                          ],
-              functionAttributes = [],
-              metadata = []
-            },
-            [lli|call void @myfunc(i8* getelementptr ([4 x i8]* @myglobal_str, i32 0, i32 0))|]),
           ("call with constant select",
             Call {
               tailCallKind = Nothing,
@@ -1983,39 +2015,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               functionAttributes = [],
               metadata = []
             },
-            [lli|call void @myfunc10({i32, i8} insertvalue ({i32, i8} {i32 41, i8 2}, i32 23, 0))|]),
-          ("call with constant getelementptr inbounds",
-            Call {
-              tailCallKind = Nothing,
-              callingConvention = CC.C,
-              returnAttributes = [],
-              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
-              arguments = [ (ConstantOperand C.GetElementPtr
-                                              { C.inBounds = True
-                                              , C.address =
-                                                C.GlobalReference
-                                                  (ptr
-                                                    ArrayType
-                                                    { nArrayElements = 4
-                                                    , elementType = i8
-                                                    })
-                                                  (Name "myglobal_str")
-                                              , C.indices =
-                                                [ C.Int
-                                                  { C.integerBits = 32
-                                                  , C.integerValue = 0
-                                                  }
-                                                , C.Int
-                                                  { C.integerBits = 32
-                                                  , C.integerValue = 0
-                                                  }
-                                                ]
-                                              }, [])
-                          ],
-              functionAttributes = [],
-              metadata = []
-            },
-            [lli|call void @myfunc(i8* getelementptr inbounds ([4 x i8]* @myglobal_str, i32 0, i32 0))|])
+            [lli|call void @myfunc10({i32, i8} insertvalue ({i32, i8} {i32 41, i8 2}, i32 23, 0))|])
          ]
    ],
 

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -82,24 +82,24 @@ instructions =
   -- , [lli|call void @myfunc2(i32 zext (i8 2 to i32))|]
   --   -- sext
   -- , [lli|call void @myfunc2(i32 sext (i8 2 to i32))|]
-    -- fptoui
-  , [lli|call void @myfunc2(i32 fptoui (float 123.0 to i32))|]
-   -- fptosi
-  , [lli|call void @myfunc2(i32 fptosi (float 123.0 to i32))|]
-    -- uitofp
-  , [lli|call void @myfunc3(float uitofp (i32 123 to float))|]
-    -- sitofp
-  , [lli|call void @myfunc3(float sitofp (i32 123 to float))|]
-    -- fptrunc
-  , [lli|call void @myfunc3(float fptrunc (double 123.0 to float))|]
-    -- fpext
-  , [lli|call void @myfunc5(double fpext (float 123.0 to double))|]
-    -- ptrtoint
-  , [lli|call void @myfunc2(i32 ptrtoint (i8* null to i32))|]
-    -- inttoptr
-  , [lli|call void @myfunc(i8* inttoptr (i32 4 to i8*))|]
-    -- addrspacecast
-  , [lli|call void @myfunc6(i8 addrspace(1)* addrspacecast (i32* null to i8 addrspace(1)*))|]
+  --   -- fptoui
+  -- , [lli|call void @myfunc2(i32 fptoui (float 123.0 to i32))|]
+  --  -- fptosi
+  -- , [lli|call void @myfunc2(i32 fptosi (float 123.0 to i32))|]
+  --   -- uitofp
+  -- , [lli|call void @myfunc3(float uitofp (i32 123 to float))|]
+  --   -- sitofp
+  -- , [lli|call void @myfunc3(float sitofp (i32 123 to float))|]
+  --   -- fptrunc
+  -- , [lli|call void @myfunc3(float fptrunc (double 123.0 to float))|]
+  --   -- fpext
+  -- , [lli|call void @myfunc5(double fpext (float 123.0 to double))|]
+  --   -- ptrtoint
+  -- , [lli|call void @myfunc2(i32 ptrtoint (i8* null to i32))|]
+  --   -- inttoptr
+  -- , [lli|call void @myfunc(i8* inttoptr (i32 4 to i8*))|]
+  --   -- addrspacecast
+  -- , [lli|call void @myfunc6(i8 addrspace(1)* addrspacecast (i32* null to i8 addrspace(1)*))|]
     -- icmp
   , [lli|call void @myfunc7(i1 icmp eq (i32 4, i32 1))|]
   , [lli|call void @myfunc7(i1 icmp ne (i32 4, i32 1))|]
@@ -684,23 +684,6 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
              metadata = []
            },
            [lli|call void @0(i32 %0, float %1, i32* %2, i64 %3, i1 %4, <2 x i32> %5, { i32, i32 } %6)|]),
-          ("call with constant bitcast",
-            Call {
-              tailCallKind = Nothing,
-              callingConvention = CC.C,
-              returnAttributes = [],
-              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
-              arguments = [ ( ConstantOperand
-                                C.BitCast
-                                { C.operand0 = (C.GlobalReference (ptr i1) (Name "myglobal"))
-                                , C.type' = (ptr i8)
-                                }
-                            , [])
-                          ],
-              functionAttributes = [],
-              metadata = []
-            },
-            [lli|call void @myfunc(i8* bitcast (i1* @myglobal to i8*))|]),
           ("call with nested constant bitcast",
             Call {
               tailCallKind = Nothing,
@@ -1582,6 +1565,184 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               metadata = []
             },
             [lli|call void @myfunc2(i32 sext (i8 2 to i32))|]),
+          ("call with constant fptoui",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.FPToUI
+                                              { C.operand0 =
+                                                C.Float
+                                                { C.floatValue = Float.Single 123.0
+                                                }
+                                              , C.type' = i32
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 fptoui (float 123.0 to i32))|]),
+          ("call with constant fptosi",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.FPToSI
+                                              { C.operand0 =
+                                                C.Float
+                                                { C.floatValue = Float.Single 123.0
+                                                }
+                                              , C.type' = i32
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 fptosi (float 123.0 to i32))|]),
+          ("call with constant uitofp",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
+              arguments = [ (ConstantOperand C.UIToFP
+                                              { C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 123
+                                                }
+                                              , C.type' = float
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc3(float uitofp (i32 123 to float))|]),
+          ("call with constant sitofp",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
+              arguments = [ (ConstantOperand C.SIToFP
+                                              { C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 123
+                                                }
+                                              , C.type' = float
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc3(float sitofp (i32 123 to float))|]),
+          ("call with constant fptrunc",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
+              arguments = [ (ConstantOperand C.FPTrunc
+                                              { C.operand0 =
+                                                C.Float
+                                                { C.floatValue = Float.Double 123.0
+                                                }
+                                              , C.type' = float
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc3(float fptrunc (double 123.0 to float))|]),
+          ("call with constant fpext",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [double] False)) (Name "myfunc5"))),
+              arguments = [ (ConstantOperand C.FPExt
+                                              { C.operand0 =
+                                                C.Float
+                                                { C.floatValue = Float.Single 123.0
+                                                }
+                                              , C.type' = double
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc5(double fpext (float 123.0 to double))|]),
+          ("call with constant ptrtoint",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+              arguments = [ (ConstantOperand C.PtrToInt
+                                              { C.operand0 = C.GlobalReference (ptr i8) (Name "myptr")
+                                              , C.type' = i32
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc2(i32 ptrtoint (i8* @myptr to i32))|]),
+          ("call with constant inttoptr",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
+              arguments = [ (ConstantOperand C.IntToPtr
+                                              { C.operand0 =
+                                                C.Int
+                                                { C.integerBits = 32
+                                                , C.integerValue = 4
+                                                }
+                                              , C.type' = ptr i8
+                                              }, [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc(i8* inttoptr (i32 4 to i8*))|]),
+          ("call with constant bitcast",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [ptr i8] False)) (Name "myfunc"))),
+              arguments = [ ( ConstantOperand
+                                C.BitCast
+                                { C.operand0 = (C.GlobalReference (ptr i1) (Name "myglobal"))
+                                , C.type' = (ptr i8)
+                                }
+                            , [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc(i8* bitcast (i1* @myglobal to i8*))|]),
+          ("call with constant addrspacecast",
+            Call {
+              tailCallKind = Nothing,
+              callingConvention = CC.C,
+              returnAttributes = [],
+              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [PointerType (IntegerType 8) (AddrSpace 1)] False)) (Name "myfunc6"))),
+              arguments = [ ( ConstantOperand
+                                C.AddrSpaceCast
+                                { C.operand0 = (C.GlobalReference (ptr i32) (Name "myglobal"))
+                                , C.type' = PointerType (IntegerType 8) (AddrSpace 1)
+                                }
+                            , [])
+                          ],
+              functionAttributes = [],
+              metadata = []
+            },
+            [lli|call void @myfunc6(i8 addrspace(1)* addrspacecast (i32* @myglobal to i8 addrspace(1)*))|]),
           ("call with constant getelementptr",
             Call {
               tailCallKind = Nothing,
@@ -1645,22 +1806,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               functionAttributes = [],
               metadata = []
             },
-            [lli|call void @myfunc(i8* getelementptr inbounds ([4 x i8]* @myglobal_str, i32 0, i32 0))|]),
-          ("call with constant ptrtoint",
-            Call {
-              tailCallKind = Nothing,
-              callingConvention = CC.C,
-              returnAttributes = [],
-              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
-              arguments = [ (ConstantOperand C.PtrToInt
-                                              { C.operand0 = C.GlobalReference (ptr i8) (Name "myptr")
-                                              , C.type' = i32
-                                              }, [])
-                          ],
-              functionAttributes = [],
-              metadata = []
-            },
-            [lli|call void @myfunc2(i32 ptrtoint (i8* @myptr to i32))|])
+            [lli|call void @myfunc(i8* getelementptr inbounds ([4 x i8]* @myglobal_str, i32 0, i32 0))|])
          ]
    ],
 

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -692,6 +692,126 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
                    metadata = []
                  },
                  [lli|call void @myfunc3(float fadd (float 0.5, float 0.25))|]),
+               ("call with constant sub",
+                 Call {
+                   tailCallKind = Nothing,
+                   callingConvention = CC.C,
+                   returnAttributes = [],
+                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                   arguments = [ (ConstantOperand (C.Sub False False (C.Int 32 1) (C.Int 32 2)), [])
+                               ],
+                   functionAttributes = [],
+                   metadata = []
+                 },
+                 [lli|call void @myfunc2(i32 sub (i32 1, i32 2))|]),
+               ("call with constant sub nsw",
+                 Call {
+                   tailCallKind = Nothing,
+                   callingConvention = CC.C,
+                   returnAttributes = [],
+                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                   arguments = [ (ConstantOperand (C.Sub True False (C.Int 32 1) (C.Int 32 2)), [])
+                               ],
+                   functionAttributes = [],
+                   metadata = []
+                 },
+                 [lli|call void @myfunc2(i32 sub nsw (i32 1, i32 2))|]),
+               ("call with constant sub nuw",
+                 Call {
+                   tailCallKind = Nothing,
+                   callingConvention = CC.C,
+                   returnAttributes = [],
+                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                   arguments = [ (ConstantOperand (C.Sub False True (C.Int 32 1) (C.Int 32 2)), [])
+                               ],
+                   functionAttributes = [],
+                   metadata = []
+                 },
+                 [lli|call void @myfunc2(i32 sub nuw (i32 1, i32 2))|]),
+               ("call with constant sub nsw nuw",
+                 Call {
+                   tailCallKind = Nothing,
+                   callingConvention = CC.C,
+                   returnAttributes = [],
+                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                   arguments = [ (ConstantOperand (C.Sub True True (C.Int 32 1) (C.Int 32 2)), [])
+                               ],
+                   functionAttributes = [],
+                   metadata = []
+                 },
+                 [lli|call void @myfunc2(i32 sub nsw nuw (i32 1, i32 2))|]),
+               ("call with constant fsub",
+                Call {
+                  tailCallKind = Nothing,
+                  callingConvention = CC.C,
+                  returnAttributes = [],
+                  function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
+                  arguments = [ (ConstantOperand (C.FSub (C.Float (Float.Single 0.5)) (C.Float (Float.Single 0.25))), [])
+                              ],
+                  functionAttributes = [],
+                  metadata = []
+                },
+                [lli|call void @myfunc3(float fsub (float 0.5, float 0.25))|]),
+               ("call with constant mul",
+                  Call {
+                    tailCallKind = Nothing,
+                    callingConvention = CC.C,
+                    returnAttributes = [],
+                    function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                    arguments = [ (ConstantOperand (C.Mul False False (C.Int 32 1) (C.Int 32 2)), [])
+                                ],
+                    functionAttributes = [],
+                    metadata = []
+                  },
+                  [lli|call void @myfunc2(i32 mul (i32 1, i32 2))|]),
+               ("call with constant mul nsw",
+                 Call {
+                   tailCallKind = Nothing,
+                   callingConvention = CC.C,
+                   returnAttributes = [],
+                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                   arguments = [ (ConstantOperand (C.Mul True False (C.Int 32 1) (C.Int 32 2)), [])
+                               ],
+                   functionAttributes = [],
+                   metadata = []
+                 },
+                 [lli|call void @myfunc2(i32 mul nsw (i32 1, i32 2))|]),
+               ("call with constant mul nuw",
+                 Call {
+                   tailCallKind = Nothing,
+                   callingConvention = CC.C,
+                   returnAttributes = [],
+                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                   arguments = [ (ConstantOperand (C.Mul False True (C.Int 32 1) (C.Int 32 2)), [])
+                               ],
+                   functionAttributes = [],
+                   metadata = []
+                 },
+                 [lli|call void @myfunc2(i32 mul nuw (i32 1, i32 2))|]),
+               ("call with constant mul nsw nuw",
+                 Call {
+                   tailCallKind = Nothing,
+                   callingConvention = CC.C,
+                   returnAttributes = [],
+                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [i32] False)) (Name "myfunc2"))),
+                   arguments = [ (ConstantOperand (C.Mul True True (C.Int 32 1) (C.Int 32 2)), [])
+                               ],
+                   functionAttributes = [],
+                   metadata = []
+                 },
+                 [lli|call void @myfunc2(i32 mul nsw nuw (i32 1, i32 2))|]),
+               ("call with constant fmul",
+                 Call {
+                   tailCallKind = Nothing,
+                   callingConvention = CC.C,
+                   returnAttributes = [],
+                   function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType void [float] False)) (Name "myfunc3"))),
+                   arguments = [ (ConstantOperand (C.FMul (C.Float (Float.Single 0.5)) (C.Float (Float.Single 0.25))), [])
+                               ],
+                   functionAttributes = [],
+                   metadata = []
+                 },
+                 [lli|call void @myfunc3(float fmul (float 0.5, float 0.25))|]),
                ("call with constant getelementptr",
                  Call {
                    tailCallKind = Nothing,


### PR DESCRIPTION
This pull request is for support of LLVM [constant expressions](https://llvm.org/docs/LangRef.html#constant-expressions). Many LLVM IR use constant expressions like the following `getelementptr` and `bitcast`.

```ll
call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @lf_format, i32 0, i32 0), double 1.100000e+01)
```

```ll
call void @myfunc(i8* bitcast (i32* @myglobal to i8*))
```

So I'd like to use this feature in llvm-hs-quote.
In addition, nested constant expression bellow is also available like LLVM IR.

```hs
-- (5 * 10) + 2
[lli|call void @myfunc2(i32 add (i32 mul (i32 5, i32 10), i32 2))|]
```