### PR TITLE
Fix `declare` parser to to use function attributes

### DIFF
--- a/src/LLVM/Quote/Parser/Parser.y
+++ b/src/LLVM/Quote/Parser/Parser.y
@@ -983,8 +983,8 @@ global :: { A.Global }
 global :
     'define' linkage visibility cconv parameterAttributes type globalName '(' parameterList ')' fAttributes section alignment gc '{' instructions '}'
       { A.Function $2 $3 Nothing $4 (rev $5) $6 $7 $9 (map Right $ rev $11) $12 Nothing $13 $14 Nothing (rev $16) Nothing }
-  | 'declare' linkage visibility cconv parameterAttributes type globalName '(' parameterListD ')' alignment gc
-      { A.Function $2 $3 Nothing $4 (rev $5) $6 $7 $9 [] Nothing Nothing $11 $12 Nothing [] Nothing }
+  | 'declare' linkage visibility cconv parameterAttributes type globalName '(' parameterListD ')' fAttributes alignment gc
+      { A.Function $2 $3 Nothing $4 (rev $5) $6 $7 $9 (map Right $ rev $11) Nothing Nothing $12 $13 Nothing [] Nothing }
   | globalName '=' linkage visibility isConstant type mConstant alignment
       { A.GlobalVariable $1 $3 $4 Nothing Nothing Nothing $5 $6 (A.AddrSpace 0) ($7 $6) Nothing Nothing $8 }
   | globalName '=' visibility 'alias' linkage type constant

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -43,6 +43,10 @@ retWithName ty name = [llt|ret $type:ty $id:name|]
 retWithOp :: Type -> Operand -> Terminator
 retWithOp ty op = [llt|ret $type:ty $opr:op|]
 
+-- `declare` with function attribute
+def1 :: Definition
+def1 = [lldef|declare void @llvm.gcroot(i8**, i8*) nounwind|]
+
 tests :: TestTree
 tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
   testGroup "regular" [


### PR DESCRIPTION
Hi, developers.

This PR is a solution of the following problem.

The following `lldef` below had a compile error.

```hs
-- `declare` with function attribute
def1 :: Definition
def1 = [lldef|declare void @llvm.gcroot(i8**, i8*) nounwind|]
```
Compile error:

```txt
    parse error on `nounwind'
    • In the quasi-quotation:
        [lldef|declare void @llvm.gcroot(i8**, i8*) nounwind|]
   |         
48 | def1 = [lldef|declare void @llvm.gcroot(i8**, i8*) nounwind|]
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             
```

In LLVM IR, the following statement is valid. So this PR is a solution.

```ll
declare void @llvm.gcroot(i8**, i8*) nounwind
```
