### PR TITLE
Modify Example2.hs to be loadable in current status

### DIFF
--- a/Example2.hs
+++ b/Example2.hs
@@ -13,37 +13,53 @@ saxpy :: AST.Module
 saxpy = [Q.llmod|
 ; ModuleID = 'saxpy.ll'
 
+; (from: https://llvm.org/docs/LangRef.html#llvm-donothing-intrinsic)
+; (from: https://stackoverflow.com/a/29419659/2885946)
+declare void @llvm.donothing()
+
 define void @saxpy(i32* noalias nocapture %x, i32* noalias nocapture %y, i32 %a, i64 %i) {
 entry:
-  %1 = getelementptr inbounds i32, i32* %x, i64 %i
-  %2 = load i32, i32* %1, align 4
+  %1 = getelementptr inbounds i32* %x, i64 %i
+    call void @llvm.donothing()
+  %2 = load i32* %1, align 4
   %3 = mul nsw i32 %2, %a
-  %4 = getelementptr inbounds i32, i32* %y, i64 %i
-  %5 = load i32, i32* %4, align 4
+    call void @llvm.donothing()
+  %4 = getelementptr inbounds i32* %y, i64 %i
+    call void @llvm.donothing()
+  %5 = load i32* %4, align 4
   %6 = add nsw i32 %3, %5
   store i32 %6, i32* %1, align 4
   %7 = add i64 %i, 1
-  %8 = getelementptr inbounds i32, i32* %x, i64 %7
-  %9 = load i32, i32* %8, align 4
+  %8 = getelementptr inbounds i32* %x, i64 %7
+    call void @llvm.donothing()
+  %9 = load i32* %8, align 4
   %10 = mul nsw i32 %9, %a
-  %11 = getelementptr inbounds i32, i32* %y, i64 %7
-  %12 = load i32, i32* %11, align 4
+    call void @llvm.donothing()
+  %11 = getelementptr inbounds i32* %y, i64 %7
+    call void @llvm.donothing()
+  %12 = load i32* %11, align 4
   %13 = add nsw i32 %10, %12
   store i32 %13, i32* %8, align 4
   %14 = add i64 %i, 2
-  %15 = getelementptr inbounds i32, i32* %x, i64 %14
-  %16 = load i32, i32* %15, align 4
+  %15 = getelementptr inbounds i32* %x, i64 %14
+    call void @llvm.donothing()
+  %16 = load i32* %15, align 4
   %17 = mul nsw i32 %16, %a
-  %18 = getelementptr inbounds i32, i32* %y, i64 %14
-  %19 = load i32, i32* %18, align 4
+    call void @llvm.donothing()
+  %18 = getelementptr inbounds i32* %y, i64 %14
+    call void @llvm.donothing()
+  %19 = load i32* %18, align 4
   %20 = add nsw i32 %17, %19
   store i32 %20, i32* %15, align 4
   %21 = add i64 %i, 3
-  %22 = getelementptr inbounds i32, i32* %x, i64 %21
-  %23 = load i32, i32* %22, align 4
+  %22 = getelementptr inbounds i32* %x, i64 %21
+    call void @llvm.donothing()
+  %23 = load i32* %22, align 4
   %24 = mul nsw i32 %23, %a
-  %25 = getelementptr inbounds i32, i32* %y, i64 %21
-  %26 = load i32, i32* %25, align 4
+    call void @llvm.donothing()
+  %25 = getelementptr inbounds i32* %y, i64 %21
+    call void @llvm.donothing()
+  %26 = load i32* %25, align 4
   %27 = add nsw i32 %24, %26
   store i32 %27, i32* %22, align 4
   ret void

--- a/Example2.hs
+++ b/Example2.hs
@@ -15,7 +15,7 @@ saxpy = [Q.llmod|
 
 ; (from: https://llvm.org/docs/LangRef.html#llvm-donothing-intrinsic)
 ; (from: https://stackoverflow.com/a/29419659/2885946)
-declare void @llvm.donothing()
+declare void @llvm.donothing() nounwind readnone
 
 define void @saxpy(i32* noalias nocapture %x, i32* noalias nocapture %y, i32 %a, i64 %i) {
 entry:

--- a/Example2.hs
+++ b/Example2.hs
@@ -19,47 +19,47 @@ declare void @llvm.donothing()
 
 define void @saxpy(i32* noalias nocapture %x, i32* noalias nocapture %y, i32 %a, i64 %i) {
 entry:
-  %1 = getelementptr inbounds i32* %x, i64 %i
+  %1 = getelementptr inbounds i32, i32* %x, i64 %i
     call void @llvm.donothing()
-  %2 = load i32* %1, align 4
+  %2 = load i32, i32* %1, align 4
   %3 = mul nsw i32 %2, %a
     call void @llvm.donothing()
-  %4 = getelementptr inbounds i32* %y, i64 %i
+  %4 = getelementptr inbounds i32, i32* %y, i64 %i
     call void @llvm.donothing()
-  %5 = load i32* %4, align 4
+  %5 = load i32, i32* %4, align 4
   %6 = add nsw i32 %3, %5
   store i32 %6, i32* %1, align 4
   %7 = add i64 %i, 1
-  %8 = getelementptr inbounds i32* %x, i64 %7
+  %8 = getelementptr inbounds i32, i32* %x, i64 %7
     call void @llvm.donothing()
-  %9 = load i32* %8, align 4
+  %9 = load i32, i32* %8, align 4
   %10 = mul nsw i32 %9, %a
     call void @llvm.donothing()
-  %11 = getelementptr inbounds i32* %y, i64 %7
+  %11 = getelementptr inbounds i32, i32* %y, i64 %7
     call void @llvm.donothing()
-  %12 = load i32* %11, align 4
+  %12 = load i32, i32* %11, align 4
   %13 = add nsw i32 %10, %12
   store i32 %13, i32* %8, align 4
   %14 = add i64 %i, 2
-  %15 = getelementptr inbounds i32* %x, i64 %14
+  %15 = getelementptr inbounds i32, i32* %x, i64 %14
     call void @llvm.donothing()
-  %16 = load i32* %15, align 4
+  %16 = load i32, i32* %15, align 4
   %17 = mul nsw i32 %16, %a
     call void @llvm.donothing()
-  %18 = getelementptr inbounds i32* %y, i64 %14
+  %18 = getelementptr inbounds i32, i32* %y, i64 %14
     call void @llvm.donothing()
-  %19 = load i32* %18, align 4
+  %19 = load i32, i32* %18, align 4
   %20 = add nsw i32 %17, %19
   store i32 %20, i32* %15, align 4
   %21 = add i64 %i, 3
-  %22 = getelementptr inbounds i32* %x, i64 %21
+  %22 = getelementptr inbounds i32, i32* %x, i64 %21
     call void @llvm.donothing()
-  %23 = load i32* %22, align 4
+  %23 = load i32, i32* %22, align 4
   %24 = mul nsw i32 %23, %a
     call void @llvm.donothing()
-  %25 = getelementptr inbounds i32* %y, i64 %21
+  %25 = getelementptr inbounds i32, i32* %y, i64 %21
     call void @llvm.donothing()
-  %26 = load i32* %25, align 4
+  %26 = load i32, i32* %25, align 4
   %27 = add nsw i32 %24, %26
   store i32 %27, i32* %22, align 4
   ret void


### PR DESCRIPTION
Hi, developers.

I just modified `Example2.hs` to be loadable in current status. This change contains my dirty technique to write parsable quote.

NOTE:  I think you don't have to merge this change. This is just my idea. But if you like it, you can merge this.

## My test command

This is my test command to confirm whether loadable or not

```bash
$ cd llvm-hs-quote/
$ stack build
$ stack ghci
... some messages ...
> :load Example2
... some messages ...
[9 of 9] Compiling Example2         ( Example2.hs, interpreted )
Ok, 9 modules loaded.
```


## Changes

Here is explanation of changes. My changes has three methods.

### Method 1. `getelementptr`
 e.g. Replace `getelementptr inbounds i32, i32* %x, i64 %14` => `getelementptr inbounds i32* %x, i64 %14`

### Method 2. `load`

e.g. Replace `load i32, i32* %8, align 4` => `load i32* %8, align 4`

### Method 3.  Add `call void @llvm.donothing()`

Add `@llvm.donothing()` between 

* `getelementptr`  and `load`
* `mul` and `getelementptr`

I think Method 1 & 2 is the specification of llvm-quote-hs, but Method 3 is not beautiful solution. So I gave some indentation before `call void @llvm.donothing()`.

I hope that it will be helpful for other or future library users and be helpful to fix the parser!
