### PR TITLE
Fix parsing of `getelementptr` constant expression

### DIFF
--- a/src/LLVM/Quote/Parser/Parser.y
+++ b/src/LLVM/Quote/Parser/Parser.y
@@ -357,7 +357,8 @@ constantExpression :
   | 'and' '(' tConstant ',' tConstant ')'                          { A.And' $3 $5 }
   | 'or' '(' tConstant ',' tConstant ')'                           { A.Or' $3 $5 }
   | 'xor' '(' tConstant ',' tConstant ')'                          { A.Xor' $3 $5 }
-  | 'getelementptr' inBounds '(' tConstant constantIndices ')'     { A.GetElementPtr' $2 $4 (rev $5) }
+  | 'getelementptr' inBounds '(' type ','  tConstant constantIndices ')'
+                                                                   { A.GetElementPtr' $2 $6 (rev $7) }
   | 'trunc' '(' tConstant 'to' type ')'                            { A.Trunc' $3 $5 }
   | 'zext' '(' tConstant 'to' type ')'                             { A.ZExt' $3 $5 }
   | 'sext' '(' tConstant 'to' type ')'                             { A.SExt' $3 $5 }

--- a/test/LLVM/Quote/Test/Instructions.hs
+++ b/test/LLVM/Quote/Test/Instructions.hs
@@ -1489,7 +1489,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               functionAttributes = [],
               metadata = []
             },
-            [lli|call void @myfunc(i8* getelementptr ([4 x i8]* @myglobal_str, i32 0, i32 0))|]),
+            [lli|call void @myfunc(i8* getelementptr ([4 x i8], [4 x i8]* @myglobal_str, i32 0, i32 0))|]),
           ("call with constant getelementptr inbounds",
             Call {
               tailCallKind = Nothing,
@@ -1521,7 +1521,7 @@ tests = let a t = LocalReference t . UnName in testGroup "Instructions" [
               functionAttributes = [],
               metadata = []
             },
-            [lli|call void @myfunc(i8* getelementptr inbounds ([4 x i8]* @myglobal_str, i32 0, i32 0))|]),
+            [lli|call void @myfunc(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @myglobal_str, i32 0, i32 0))|]),
           ("call with constant trunc",
             Call {
               tailCallKind = Nothing,


### PR DESCRIPTION
This PR fixes parsing of `getelementptr` constant expression related to #24.

So syntax will be changed like the following.

### before PR

```hs
[lli|call void @myfunc(i8* getelementptr ([4 x i8]* @myglobal_str, i32 0, i32 0))|]
```

### after PR

```hs
[lli|call void @myfunc(i8* getelementptr ([4 x i8], [4 x i8]* @myglobal_str, i32 0, i32 0))|]
```